### PR TITLE
Allocate sufficient memory for Hungarian if number of batches > 1

### DIFF
--- a/cpp/include/raft/lap/detail/lap_functions.cuh
+++ b/cpp/include/raft/lap/detail/lap_functions.cuh
@@ -466,7 +466,7 @@ inline void dualUpdate(raft::handle_t const& handle,
   dim3 threads_per_block;
   int total_blocks;
 
-  rmm::device_scalar<weight_t> sp_min_v(handle.get_stream());
+  rmm::device_uvector<weight_t> sp_min_v(SP, handle.get_stream());
 
   raft::lap::detail::calculateLinearDims(blocks_per_grid, threads_per_block, total_blocks, SP);
   kernel_dualUpdate_1<<<blocks_per_grid, threads_per_block, 0, handle.get_stream()>>>(


### PR DESCRIPTION
Addresses Hungarian bug described in #528.

The `dualUpdate` method was originally using an array of size one which was eventually changed to a scalar.  It really needs to be an array of size SP (number of subproblems in Date/Nagi nomenclature, number of batches as integrated into raft).