### PR TITLE
Refactor spectral scale_obs to use existing normalization function

### DIFF
--- a/cpp/include/raft/linalg/normalize.cuh
+++ b/cpp/include/raft/linalg/normalize.cuh
@@ -18,9 +18,11 @@
 
 #include "detail/normalize.cuh"
 
+#include <raft/core/device_mdspan.hpp>
 #include <raft/core/operators.hpp>
 #include <raft/core/resource/cuda_stream.hpp>
 #include <raft/linalg/norm_types.hpp>
+#include <raft/util/input_validation.hpp>
 
 namespace raft {
 namespace linalg {

--- a/cpp/include/raft/spectral/detail/modularity_maximization.hpp
+++ b/cpp/include/raft/spectral/detail/modularity_maximization.hpp
@@ -101,7 +101,7 @@ std::tuple<vertex_t, weight_t, vertex_t> modularity_maximization(
 
   // notice that at this point the matrix has already been transposed, so we are scaling
   // columns
-  scale_obs(nEigVecs, n, eigVecs);
+  scale_obs(handle, nEigVecs, n, eigVecs);
   RAFT_CHECK_CUDA(stream);
 
   // Find partition clustering

--- a/cpp/include/raft/spectral/detail/spectral_util.cuh
+++ b/cpp/include/raft/spectral/detail/spectral_util.cuh
@@ -39,30 +39,6 @@
 namespace raft {
 namespace spectral {
 
-template <typename index_type_t, typename value_type_t>
-cudaError_t scale_obs(raft::resources const& handle,
-                      index_type_t m,
-                      index_type_t n,
-                      value_type_t* obs)
-{
-  auto thrust_exec_policy = resource::get_thrust_policy(handle);
-  thrust::for_each(thrust_exec_policy,
-                   thrust::make_counting_iterator<index_type_t>(0),
-                   thrust::make_counting_iterator<index_type_t>(n),
-                   [m, obs] __device__(index_type_t j) {
-                     value_type_t norm{0};
-                     for (index_type_t i = 0; i < m; ++i) {
-                       norm += obs[i + j * m] * obs[i + j * m];
-                     }
-                     norm = raft::sqrt(norm);
-                     for (index_type_t i = 0; i < m; ++i) {
-                       obs[i + j * m] /= norm;
-                     }
-                   });
-
-  return cudaSuccess;
-}
-
 template <typename vertex_t, typename edge_t, typename weight_t>
 void transform_eigen_matrix(raft::resources const& handle,
                             edge_t n,


### PR DESCRIPTION
The scale_obs function was calling a custom kernel to scale the elements of a matrix column by the l2-norm of the column.

There were two issues:
1. The kernel launch parameters would go out of bounds if the graph was too large.  The Y dimension is limited to 65535, but there was no logic in the function to ensure that we didn't set the Y value larger than that
3. A bug in the kernel, the column norm was not being calculated correctly... the outer loop was terminating, hence we were really only computing the column norm of the last column in the block.  Then we were normalizing all columns in the block by that value instead of by each value.

To simplify (there's going to be some optimization work done this summer), I replaced this with a simple thrust call that will scale the values correctly.