### PR TITLE
Restore tracked device resources on their original GPU

### DIFF
--- a/cpp/include/raft/core/memory_stats_resources.hpp
+++ b/cpp/include/raft/core/memory_stats_resources.hpp
@@ -4,7 +4,7 @@
  */
 #pragma once
 
-#include <raft/core/device_setter.hpp>
+#include <raft/core/resource/device_id.hpp>
 #include <raft/core/resource/device_memory_resource.hpp>
 #include <raft/core/resource/managed_memory_resource.hpp>
 #include <raft/core/resource/pinned_memory_resource.hpp>
@@ -77,9 +77,9 @@ class memory_stats_resources : public resources {
  public:
   explicit memory_stats_resources(const resources& existing)
     : resources(existing),
-      device_id_(device_setter::get_current_device()),
       old_host_(mr::get_default_host_resource()),
-      old_device_(rmm::mr::get_current_device_resource_ref())
+      old_device_(rmm::mr::get_per_device_resource_ref(
+        rmm::cuda_device_id{resource::get_device_id(*this)}))
   {
     init();
   }
@@ -87,7 +87,8 @@ class memory_stats_resources : public resources {
   ~memory_stats_resources() override
   {
     mr::set_default_host_resource(old_host_);
-    rmm::mr::set_per_device_resource(rmm::cuda_device_id{device_id_}, std::move(old_device_));
+    rmm::mr::set_per_device_resource(rmm::cuda_device_id{resource::get_device_id(*this)},
+                                     std::move(old_device_));
   }
 
   memory_stats_resources(memory_stats_resources const&)            = delete;
@@ -145,7 +146,6 @@ class memory_stats_resources : public resources {
 
   std::vector<std::shared_ptr<resource::resource_cell>> snapshot_;
 
-  int device_id_;
   raft::mr::host_resource old_host_;
   raft::mr::device_resource old_device_;
 

--- a/cpp/include/raft/core/memory_stats_resources.hpp
+++ b/cpp/include/raft/core/memory_stats_resources.hpp
@@ -218,7 +218,8 @@ class memory_stats_resources : public resources {
       device_stats_adaptor_t sa{rmm::device_async_resource_ref{old_device_}};
       device_stats_   = sa.get_stats();
       device_adaptor_ = std::make_unique<device_stats_adaptor_t>(std::move(sa));
-      rmm::mr::set_current_device_resource(*device_adaptor_);
+      rmm::mr::set_per_device_resource(rmm::cuda_device_id{resource::get_device_id(*this)},
+                                       *device_adaptor_);
     }
     // --- Workspace ---
     {

--- a/cpp/include/raft/core/memory_stats_resources.hpp
+++ b/cpp/include/raft/core/memory_stats_resources.hpp
@@ -4,6 +4,7 @@
  */
 #pragma once
 
+#include <raft/core/device_setter.hpp>
 #include <raft/core/resource/device_memory_resource.hpp>
 #include <raft/core/resource/managed_memory_resource.hpp>
 #include <raft/core/resource/pinned_memory_resource.hpp>
@@ -76,6 +77,7 @@ class memory_stats_resources : public resources {
  public:
   explicit memory_stats_resources(const resources& existing)
     : resources(existing),
+      device_id_(device_setter::get_current_device()),
       old_host_(mr::get_default_host_resource()),
       old_device_(rmm::mr::get_current_device_resource_ref())
   {
@@ -85,7 +87,7 @@ class memory_stats_resources : public resources {
   ~memory_stats_resources() override
   {
     mr::set_default_host_resource(old_host_);
-    rmm::mr::set_current_device_resource(std::move(old_device_));
+    rmm::mr::set_per_device_resource(rmm::cuda_device_id{device_id_}, std::move(old_device_));
   }
 
   memory_stats_resources(memory_stats_resources const&)            = delete;
@@ -143,6 +145,7 @@ class memory_stats_resources : public resources {
 
   std::vector<std::shared_ptr<resource::resource_cell>> snapshot_;
 
+  int device_id_;
   raft::mr::host_resource old_host_;
   raft::mr::device_resource old_device_;
 

--- a/cpp/include/raft/core/memory_stats_resources.hpp
+++ b/cpp/include/raft/core/memory_stats_resources.hpp
@@ -78,8 +78,8 @@ class memory_stats_resources : public resources {
   explicit memory_stats_resources(const resources& existing)
     : resources(existing),
       old_host_(mr::get_default_host_resource()),
-      old_device_(rmm::mr::get_per_device_resource_ref(
-        rmm::cuda_device_id{resource::get_device_id(*this)}))
+      old_device_(
+        rmm::mr::get_per_device_resource_ref(rmm::cuda_device_id{resource::get_device_id(*this)}))
   {
     init();
   }

--- a/cpp/include/raft/core/memory_stats_resources.hpp
+++ b/cpp/include/raft/core/memory_stats_resources.hpp
@@ -4,6 +4,7 @@
  */
 #pragma once
 
+#include <raft/core/logger.hpp>
 #include <raft/core/resource/device_id.hpp>
 #include <raft/core/resource/device_memory_resource.hpp>
 #include <raft/core/resource/managed_memory_resource.hpp>
@@ -21,6 +22,7 @@
 
 #include <cstddef>
 #include <cstdint>
+#include <exception>
 #include <memory>
 #include <utility>
 #include <vector>
@@ -87,8 +89,17 @@ class memory_stats_resources : public resources {
   ~memory_stats_resources() override
   {
     mr::set_default_host_resource(old_host_);
-    rmm::mr::set_per_device_resource(rmm::cuda_device_id{resource::get_device_id(*this)},
-                                     std::move(old_device_));
+    try {
+      rmm::mr::set_per_device_resource(rmm::cuda_device_id{resource::get_device_id(*this)},
+                                       std::move(old_device_));
+    } catch (const std::exception& e) {
+      RAFT_LOG_ERROR("memory_stats_resources failed to restore the per-device memory resource: %s",
+                     e.what());
+    } catch (...) {
+      RAFT_LOG_ERROR(
+        "memory_stats_resources failed to restore the per-device memory resource: unknown "
+        "exception");
+    }
   }
 
   memory_stats_resources(memory_stats_resources const&)            = delete;

--- a/cpp/include/raft/core/memory_tracking_resources.hpp
+++ b/cpp/include/raft/core/memory_tracking_resources.hpp
@@ -5,7 +5,7 @@
 #pragma once
 
 #include <raft/core/detail/macros.hpp>
-#include <raft/core/device_setter.hpp>
+#include <raft/core/resource/device_id.hpp>
 #include <raft/core/resource/device_memory_resource.hpp>
 #include <raft/core/resource/managed_memory_resource.hpp>
 #include <raft/core/resource/pinned_memory_resource.hpp>
@@ -109,7 +109,8 @@ class memory_tracking_resources : public resources {
   {
     report_.stop();
     raft::mr::set_default_host_resource(old_host_);
-    rmm::mr::set_per_device_resource(rmm::cuda_device_id{device_id_}, std::move(old_device_));
+    rmm::mr::set_per_device_resource(rmm::cuda_device_id{resource::get_device_id(*this)},
+                                     std::move(old_device_));
   }
 
   memory_tracking_resources(memory_tracking_resources const&)            = delete;
@@ -128,9 +129,9 @@ class memory_tracking_resources : public resources {
     : resources(existing ? *existing : resources{}),
       owned_stream_(std::move(owned_stream)),
       report_(out_override ? *out_override : *owned_stream_, sample_interval),
-      device_id_(device_setter::get_current_device()),
       old_host_(raft::mr::get_default_host_resource()),
-      old_device_(rmm::mr::get_current_device_resource_ref())
+      old_device_(rmm::mr::get_per_device_resource_ref(
+        rmm::cuda_device_id{resource::get_device_id(*this)}))
   {
     init();
   }
@@ -143,7 +144,6 @@ class memory_tracking_resources : public resources {
   std::unique_ptr<std::ofstream> owned_stream_;
   raft::mr::resource_monitor report_;
 
-  int device_id_;
   raft::mr::host_resource old_host_;
   raft::mr::device_resource old_device_;
 

--- a/cpp/include/raft/core/memory_tracking_resources.hpp
+++ b/cpp/include/raft/core/memory_tracking_resources.hpp
@@ -220,7 +220,8 @@ class memory_tracking_resources : public resources {
       device_stats_t sa{rmm::device_async_resource_ref{old_device_}};
       report_.register_source("device", sa.get_stats());
       device_adaptor_ = std::make_unique<device_notify_t>(std::move(sa), report_.get_notifier());
-      rmm::mr::set_current_device_resource(*device_adaptor_);
+      rmm::mr::set_per_device_resource(rmm::cuda_device_id{resource::get_device_id(*this)},
+                                       *device_adaptor_);
     }
 
     // --- Workspace (track upstream to preserve limiting_resource_adaptor) ---

--- a/cpp/include/raft/core/memory_tracking_resources.hpp
+++ b/cpp/include/raft/core/memory_tracking_resources.hpp
@@ -5,6 +5,7 @@
 #pragma once
 
 #include <raft/core/detail/macros.hpp>
+#include <raft/core/device_setter.hpp>
 #include <raft/core/resource/device_memory_resource.hpp>
 #include <raft/core/resource/managed_memory_resource.hpp>
 #include <raft/core/resource/pinned_memory_resource.hpp>
@@ -108,7 +109,7 @@ class memory_tracking_resources : public resources {
   {
     report_.stop();
     raft::mr::set_default_host_resource(old_host_);
-    rmm::mr::set_current_device_resource(old_device_);
+    rmm::mr::set_per_device_resource(rmm::cuda_device_id{device_id_}, std::move(old_device_));
   }
 
   memory_tracking_resources(memory_tracking_resources const&)            = delete;
@@ -127,6 +128,7 @@ class memory_tracking_resources : public resources {
     : resources(existing ? *existing : resources{}),
       owned_stream_(std::move(owned_stream)),
       report_(out_override ? *out_override : *owned_stream_, sample_interval),
+      device_id_(device_setter::get_current_device()),
       old_host_(raft::mr::get_default_host_resource()),
       old_device_(rmm::mr::get_current_device_resource_ref())
   {
@@ -141,6 +143,7 @@ class memory_tracking_resources : public resources {
   std::unique_ptr<std::ofstream> owned_stream_;
   raft::mr::resource_monitor report_;
 
+  int device_id_;
   raft::mr::host_resource old_host_;
   raft::mr::device_resource old_device_;
 

--- a/cpp/include/raft/core/memory_tracking_resources.hpp
+++ b/cpp/include/raft/core/memory_tracking_resources.hpp
@@ -130,8 +130,8 @@ class memory_tracking_resources : public resources {
       owned_stream_(std::move(owned_stream)),
       report_(out_override ? *out_override : *owned_stream_, sample_interval),
       old_host_(raft::mr::get_default_host_resource()),
-      old_device_(rmm::mr::get_per_device_resource_ref(
-        rmm::cuda_device_id{resource::get_device_id(*this)}))
+      old_device_(
+        rmm::mr::get_per_device_resource_ref(rmm::cuda_device_id{resource::get_device_id(*this)}))
   {
     init();
   }

--- a/cpp/include/raft/core/memory_tracking_resources.hpp
+++ b/cpp/include/raft/core/memory_tracking_resources.hpp
@@ -5,6 +5,7 @@
 #pragma once
 
 #include <raft/core/detail/macros.hpp>
+#include <raft/core/logger.hpp>
 #include <raft/core/resource/device_id.hpp>
 #include <raft/core/resource/device_memory_resource.hpp>
 #include <raft/core/resource/managed_memory_resource.hpp>
@@ -23,6 +24,7 @@
 #include <cuda/stream_ref>
 
 #include <chrono>
+#include <exception>
 #include <fstream>
 #include <memory>
 #include <ostream>
@@ -109,8 +111,17 @@ class memory_tracking_resources : public resources {
   {
     report_.stop();
     raft::mr::set_default_host_resource(old_host_);
-    rmm::mr::set_per_device_resource(rmm::cuda_device_id{resource::get_device_id(*this)},
-                                     std::move(old_device_));
+    try {
+      rmm::mr::set_per_device_resource(rmm::cuda_device_id{resource::get_device_id(*this)},
+                                       std::move(old_device_));
+    } catch (const std::exception& e) {
+      RAFT_LOG_ERROR(
+        "memory_tracking_resources failed to restore the per-device memory resource: %s", e.what());
+    } catch (...) {
+      RAFT_LOG_ERROR(
+        "memory_tracking_resources failed to restore the per-device memory resource: unknown "
+        "exception");
+    }
   }
 
   memory_tracking_resources(memory_tracking_resources const&)            = delete;

--- a/cpp/tests/core/memory_stats_resources.cpp
+++ b/cpp/tests/core/memory_stats_resources.cpp
@@ -4,19 +4,37 @@
  */
 
 #include <raft/core/memory_stats_resources.hpp>
+#include <raft/core/device_setter.hpp>
 #include <raft/core/resource/device_memory_resource.hpp>
 #include <raft/core/resources.hpp>
 
+#include <rmm/mr/cuda_memory_resource.hpp>
 #include <rmm/mr/per_device_resource.hpp>
+#include <rmm/mr/pool_memory_resource.hpp>
 #include <rmm/resource_ref.hpp>
 
+#include <cuda/memory_resource>
 #include <cuda/stream_ref>
 
 #include <gtest/gtest.h>
 
 #include <cstddef>
+#include <memory>
 
 namespace raft {
+namespace {
+
+struct device_resource_restore_guard {
+  int device_id;
+  raft::mr::device_resource resource;
+
+  ~device_resource_restore_guard()
+  {
+    rmm::mr::set_per_device_resource(rmm::cuda_device_id{device_id}, std::move(resource));
+  }
+};
+
+}  // namespace
 
 TEST(MemoryStatsResources, IndependentCounting_DefaultWorkspace)
 {
@@ -91,6 +109,51 @@ TEST(MemoryStatsResources, IndependentCounting_PoolWorkspace)
 
   ws_ref.deallocate(cuda::stream_ref{cudaStreamLegacy}, ws_ptr, kWsSize);
   dev_mr.deallocate(cuda::stream_ref{cudaStreamLegacy}, dev_ptr, kGlobalSize);
+}
+
+TEST(MemoryStatsResources, RestoresDeviceResourceOnConstructionDevice)
+{
+  if (device_setter::get_device_count() < 2) {
+    GTEST_SKIP() << "Requires at least 2 CUDA devices";
+  }
+
+  auto device0 = 0;
+  auto device1 = 1;
+
+  auto device0_guard = [&]() {
+    auto scoped_device = device_setter{device0};
+    auto upstream      = rmm::mr::get_current_device_resource_ref();
+    return device_resource_restore_guard{
+      device0,
+      rmm::mr::set_current_device_resource(
+        raft::mr::device_resource{rmm::mr::pool_memory_resource(upstream, 1 << 20, 2 << 20)})};
+  }();
+
+  auto device1_guard = [&]() {
+    auto scoped_device = device_setter{device1};
+    return device_resource_restore_guard{device1, rmm::mr::reset_current_device_resource()};
+  }();
+
+  {
+    auto scoped_device = device_setter{device0};
+    raft::resources res;
+    auto tracked = std::make_unique<memory_stats_resources>(res);
+    auto wrong_device = device_setter{device1};
+    static_cast<void>(wrong_device);
+    tracked.reset();
+  }
+
+  {
+    auto scoped_device = device_setter{device0};
+    auto current_mr    = rmm::mr::get_current_device_resource_ref();
+    EXPECT_NE(cuda::mr::resource_cast<rmm::mr::pool_memory_resource>(&current_mr), nullptr);
+  }
+
+  {
+    auto scoped_device = device_setter{device1};
+    auto current_mr    = rmm::mr::get_current_device_resource_ref();
+    EXPECT_NE(cuda::mr::resource_cast<rmm::mr::cuda_memory_resource>(&current_mr), nullptr);
+  }
 }
 
 }  // namespace raft

--- a/cpp/tests/core/memory_stats_resources.cpp
+++ b/cpp/tests/core/memory_stats_resources.cpp
@@ -34,6 +34,18 @@ struct device_resource_restore_guard {
   }
 };
 
+auto current_device_uses_pool_resource() -> bool
+{
+  auto current_mr = rmm::mr::get_current_device_resource_ref();
+  return cuda::mr::resource_cast<rmm::mr::pool_memory_resource>(&current_mr) != nullptr;
+}
+
+auto current_device_uses_default_cuda_resource() -> bool
+{
+  auto current_mr = rmm::mr::get_current_device_resource_ref();
+  return cuda::mr::resource_cast<rmm::mr::cuda_memory_resource>(&current_mr) != nullptr;
+}
+
 }  // namespace
 
 TEST(MemoryStatsResources, IndependentCounting_DefaultWorkspace)
@@ -153,6 +165,62 @@ TEST(MemoryStatsResources, RestoresDeviceResourceOnConstructionDevice)
     auto scoped_device = device_setter{device1};
     auto current_mr    = rmm::mr::get_current_device_resource_ref();
     EXPECT_NE(cuda::mr::resource_cast<rmm::mr::cuda_memory_resource>(&current_mr), nullptr);
+  }
+}
+
+TEST(MemoryStatsResources, InstallsTrackedResourceOnHandleDevice)
+{
+  if (device_setter::get_device_count() < 2) {
+    GTEST_SKIP() << "Requires at least 2 CUDA devices";
+  }
+
+  auto device0 = 0;
+  auto device1 = 1;
+
+  auto device0_guard = [&]() {
+    auto scoped_device = device_setter{device0};
+    auto upstream      = rmm::mr::get_current_device_resource_ref();
+    return device_resource_restore_guard{
+      device0,
+      rmm::mr::set_current_device_resource(
+        raft::mr::device_resource{rmm::mr::pool_memory_resource(upstream, 1 << 20, 2 << 20)})};
+  }();
+
+  auto device1_guard = [&]() {
+    auto scoped_device = device_setter{device1};
+    return device_resource_restore_guard{device1, rmm::mr::reset_current_device_resource()};
+  }();
+
+  {
+    auto scoped_device = device_setter{device0};
+    raft::resources res;
+    static_cast<void>(resource::get_device_id(res));
+
+    auto wrong_device = device_setter{device1};
+    static_cast<void>(wrong_device);
+    auto tracked = std::make_unique<memory_stats_resources>(res);
+
+    {
+      auto verify_device0 = device_setter{device0};
+      EXPECT_FALSE(current_device_uses_pool_resource());
+    }
+
+    {
+      auto verify_device1 = device_setter{device1};
+      EXPECT_TRUE(current_device_uses_default_cuda_resource());
+    }
+
+    tracked.reset();
+  }
+
+  {
+    auto scoped_device = device_setter{device0};
+    EXPECT_TRUE(current_device_uses_pool_resource());
+  }
+
+  {
+    auto scoped_device = device_setter{device1};
+    EXPECT_TRUE(current_device_uses_default_cuda_resource());
   }
 }
 

--- a/cpp/tests/core/memory_stats_resources.cpp
+++ b/cpp/tests/core/memory_stats_resources.cpp
@@ -1,10 +1,10 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <raft/core/memory_stats_resources.hpp>
 #include <raft/core/device_setter.hpp>
+#include <raft/core/memory_stats_resources.hpp>
 #include <raft/core/resource/device_memory_resource.hpp>
 #include <raft/core/resources.hpp>
 
@@ -125,9 +125,7 @@ TEST(MemoryStatsResources, IndependentCounting_PoolWorkspace)
 
 TEST(MemoryStatsResources, RestoresDeviceResourceOnConstructionDevice)
 {
-  if (device_setter::get_device_count() < 2) {
-    GTEST_SKIP() << "Requires at least 2 CUDA devices";
-  }
+  if (device_setter::get_device_count() < 2) { GTEST_SKIP() << "Requires at least 2 CUDA devices"; }
 
   auto device0 = 0;
   auto device1 = 1;
@@ -149,7 +147,7 @@ TEST(MemoryStatsResources, RestoresDeviceResourceOnConstructionDevice)
   {
     auto scoped_device = device_setter{device0};
     raft::resources res;
-    auto tracked = std::make_unique<memory_stats_resources>(res);
+    auto tracked      = std::make_unique<memory_stats_resources>(res);
     auto wrong_device = device_setter{device1};
     static_cast<void>(wrong_device);
     tracked.reset();
@@ -170,9 +168,7 @@ TEST(MemoryStatsResources, RestoresDeviceResourceOnConstructionDevice)
 
 TEST(MemoryStatsResources, InstallsTrackedResourceOnHandleDevice)
 {
-  if (device_setter::get_device_count() < 2) {
-    GTEST_SKIP() << "Requires at least 2 CUDA devices";
-  }
+  if (device_setter::get_device_count() < 2) { GTEST_SKIP() << "Requires at least 2 CUDA devices"; }
 
   auto device0 = 0;
   auto device1 = 1;

--- a/cpp/tests/core/memory_stats_resources.cpp
+++ b/cpp/tests/core/memory_stats_resources.cpp
@@ -3,6 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include "test_memory_resource.hpp"
+
 #include <raft/core/device_setter.hpp>
 #include <raft/core/memory_stats_resources.hpp>
 #include <raft/core/resource/device_memory_resource.hpp>
@@ -22,31 +24,6 @@
 #include <memory>
 
 namespace raft {
-namespace {
-
-struct device_resource_restore_guard {
-  int device_id;
-  raft::mr::device_resource resource;
-
-  ~device_resource_restore_guard()
-  {
-    rmm::mr::set_per_device_resource(rmm::cuda_device_id{device_id}, std::move(resource));
-  }
-};
-
-auto current_device_uses_pool_resource() -> bool
-{
-  auto current_mr = rmm::mr::get_current_device_resource_ref();
-  return cuda::mr::resource_cast<rmm::mr::pool_memory_resource>(&current_mr) != nullptr;
-}
-
-auto current_device_uses_default_cuda_resource() -> bool
-{
-  auto current_mr = rmm::mr::get_current_device_resource_ref();
-  return cuda::mr::resource_cast<rmm::mr::cuda_memory_resource>(&current_mr) != nullptr;
-}
-
-}  // namespace
 
 TEST(MemoryStatsResources, IndependentCounting_DefaultWorkspace)
 {
@@ -130,19 +107,8 @@ TEST(MemoryStatsResources, RestoresDeviceResourceOnConstructionDevice)
   auto device0 = 0;
   auto device1 = 1;
 
-  auto device0_guard = [&]() {
-    auto scoped_device = device_setter{device0};
-    auto upstream      = rmm::mr::get_current_device_resource_ref();
-    return device_resource_restore_guard{
-      device0,
-      rmm::mr::set_current_device_resource(
-        raft::mr::device_resource{rmm::mr::pool_memory_resource(upstream, 1 << 20, 2 << 20)})};
-  }();
-
-  auto device1_guard = [&]() {
-    auto scoped_device = device_setter{device1};
-    return device_resource_restore_guard{device1, rmm::mr::reset_current_device_resource()};
-  }();
+  auto device0_guard = test::install_pool_device_resource(device0);
+  auto device1_guard = test::install_default_device_resource(device1);
 
   {
     auto scoped_device = device_setter{device0};
@@ -173,19 +139,8 @@ TEST(MemoryStatsResources, InstallsTrackedResourceOnHandleDevice)
   auto device0 = 0;
   auto device1 = 1;
 
-  auto device0_guard = [&]() {
-    auto scoped_device = device_setter{device0};
-    auto upstream      = rmm::mr::get_current_device_resource_ref();
-    return device_resource_restore_guard{
-      device0,
-      rmm::mr::set_current_device_resource(
-        raft::mr::device_resource{rmm::mr::pool_memory_resource(upstream, 1 << 20, 2 << 20)})};
-  }();
-
-  auto device1_guard = [&]() {
-    auto scoped_device = device_setter{device1};
-    return device_resource_restore_guard{device1, rmm::mr::reset_current_device_resource()};
-  }();
+  auto device0_guard = test::install_pool_device_resource(device0);
+  auto device1_guard = test::install_default_device_resource(device1);
 
   {
     auto scoped_device = device_setter{device0};
@@ -198,12 +153,12 @@ TEST(MemoryStatsResources, InstallsTrackedResourceOnHandleDevice)
 
     {
       auto verify_device0 = device_setter{device0};
-      EXPECT_FALSE(current_device_uses_pool_resource());
+      EXPECT_FALSE(test::current_device_uses_pool_resource());
     }
 
     {
       auto verify_device1 = device_setter{device1};
-      EXPECT_TRUE(current_device_uses_default_cuda_resource());
+      EXPECT_TRUE(test::current_device_uses_default_cuda_resource());
     }
 
     tracked.reset();
@@ -211,12 +166,12 @@ TEST(MemoryStatsResources, InstallsTrackedResourceOnHandleDevice)
 
   {
     auto scoped_device = device_setter{device0};
-    EXPECT_TRUE(current_device_uses_pool_resource());
+    EXPECT_TRUE(test::current_device_uses_pool_resource());
   }
 
   {
     auto scoped_device = device_setter{device1};
-    EXPECT_TRUE(current_device_uses_default_cuda_resource());
+    EXPECT_TRUE(test::current_device_uses_default_cuda_resource());
   }
 }
 

--- a/cpp/tests/core/monitor_resources.cu
+++ b/cpp/tests/core/monitor_resources.cu
@@ -34,6 +34,18 @@ struct device_resource_restore_guard {
   }
 };
 
+auto current_device_uses_pool_resource() -> bool
+{
+  auto current_mr = rmm::mr::get_current_device_resource_ref();
+  return cuda::mr::resource_cast<rmm::mr::pool_memory_resource>(&current_mr) != nullptr;
+}
+
+auto current_device_uses_default_cuda_resource() -> bool
+{
+  auto current_mr = rmm::mr::get_current_device_resource_ref();
+  return cuda::mr::resource_cast<rmm::mr::cuda_memory_resource>(&current_mr) != nullptr;
+}
+
 TEST(MemoryTrackingResources, TracksDeviceAllocations)
 {
   using namespace std::chrono_literals;
@@ -108,6 +120,63 @@ TEST(MemoryTrackingResources, RestoresDeviceResourceOnConstructionDevice)
     auto scoped_device = raft::device_setter{device1};
     auto current_mr    = rmm::mr::get_current_device_resource_ref();
     EXPECT_NE(cuda::mr::resource_cast<rmm::mr::cuda_memory_resource>(&current_mr), nullptr);
+  }
+}
+
+TEST(MemoryTrackingResources, InstallsTrackedResourceOnHandleDevice)
+{
+  if (raft::device_setter::get_device_count() < 2) {
+    GTEST_SKIP() << "Requires at least 2 CUDA devices";
+  }
+
+  auto device0 = 0;
+  auto device1 = 1;
+
+  auto device0_guard = [&]() {
+    auto scoped_device = raft::device_setter{device0};
+    auto upstream      = rmm::mr::get_current_device_resource_ref();
+    return device_resource_restore_guard{
+      device0,
+      rmm::mr::set_current_device_resource(
+        raft::mr::device_resource{rmm::mr::pool_memory_resource(upstream, 1 << 20, 2 << 20)})};
+  }();
+
+  auto device1_guard = [&]() {
+    auto scoped_device = raft::device_setter{device1};
+    return device_resource_restore_guard{device1, rmm::mr::reset_current_device_resource()};
+  }();
+
+  {
+    auto scoped_device = raft::device_setter{device0};
+    raft::resources res;
+    static_cast<void>(raft::resource::get_device_id(res));
+
+    auto wrong_device = raft::device_setter{device1};
+    static_cast<void>(wrong_device);
+    std::ostringstream oss;
+    auto tracked = std::make_unique<raft::memory_tracking_resources>(res, oss);
+
+    {
+      auto verify_device0 = raft::device_setter{device0};
+      EXPECT_FALSE(current_device_uses_pool_resource());
+    }
+
+    {
+      auto verify_device1 = raft::device_setter{device1};
+      EXPECT_TRUE(current_device_uses_default_cuda_resource());
+    }
+
+    tracked.reset();
+  }
+
+  {
+    auto scoped_device = raft::device_setter{device0};
+    EXPECT_TRUE(current_device_uses_pool_resource());
+  }
+
+  {
+    auto scoped_device = raft::device_setter{device1};
+    EXPECT_TRUE(current_device_uses_default_cuda_resource());
   }
 }
 

--- a/cpp/tests/core/monitor_resources.cu
+++ b/cpp/tests/core/monitor_resources.cu
@@ -4,18 +4,35 @@
  */
 
 #include <raft/core/device_mdarray.hpp>
+#include <raft/core/device_setter.hpp>
 #include <raft/core/memory_tracking_resources.hpp>
 #include <raft/core/resources.hpp>
 
+#include <rmm/mr/cuda_memory_resource.hpp>
+#include <rmm/mr/per_device_resource.hpp>
+#include <rmm/mr/pool_memory_resource.hpp>
+
+#include <cuda/memory_resource>
 #include <gtest/gtest.h>
 
 #include <algorithm>
 #include <chrono>
+#include <memory>
 #include <sstream>
 #include <string>
 #include <thread>
 
 namespace {
+
+struct device_resource_restore_guard {
+  int device_id;
+  raft::mr::device_resource resource;
+
+  ~device_resource_restore_guard()
+  {
+    rmm::mr::set_per_device_resource(rmm::cuda_device_id{device_id}, std::move(resource));
+  }
+};
 
 TEST(MemoryTrackingResources, TracksDeviceAllocations)
 {
@@ -47,6 +64,51 @@ TEST(MemoryTrackingResources, TracksDeviceAllocations)
                           << num_lines << " lines" << std::endl
                           << "content: " << std::endl
                           << output;
+}
+
+TEST(MemoryTrackingResources, RestoresDeviceResourceOnConstructionDevice)
+{
+  if (raft::device_setter::get_device_count() < 2) {
+    GTEST_SKIP() << "Requires at least 2 CUDA devices";
+  }
+
+  auto device0 = 0;
+  auto device1 = 1;
+
+  auto device0_guard = [&]() {
+    auto scoped_device = raft::device_setter{device0};
+    auto upstream      = rmm::mr::get_current_device_resource_ref();
+    return device_resource_restore_guard{
+      device0,
+      rmm::mr::set_current_device_resource(
+        raft::mr::device_resource{rmm::mr::pool_memory_resource(upstream, 1 << 20, 2 << 20)})};
+  }();
+
+  auto device1_guard = [&]() {
+    auto scoped_device = raft::device_setter{device1};
+    return device_resource_restore_guard{device1, rmm::mr::reset_current_device_resource()};
+  }();
+
+  {
+    auto scoped_device = raft::device_setter{device0};
+    std::ostringstream oss;
+    auto tracked = std::make_unique<raft::memory_tracking_resources>(oss);
+    auto wrong_device = raft::device_setter{device1};
+    static_cast<void>(wrong_device);
+    tracked.reset();
+  }
+
+  {
+    auto scoped_device = raft::device_setter{device0};
+    auto current_mr    = rmm::mr::get_current_device_resource_ref();
+    EXPECT_NE(cuda::mr::resource_cast<rmm::mr::pool_memory_resource>(&current_mr), nullptr);
+  }
+
+  {
+    auto scoped_device = raft::device_setter{device1};
+    auto current_mr    = rmm::mr::get_current_device_resource_ref();
+    EXPECT_NE(cuda::mr::resource_cast<rmm::mr::cuda_memory_resource>(&current_mr), nullptr);
+  }
 }
 
 }  // namespace

--- a/cpp/tests/core/monitor_resources.cu
+++ b/cpp/tests/core/monitor_resources.cu
@@ -3,6 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include "test_memory_resource.hpp"
+
 #include <raft/core/device_mdarray.hpp>
 #include <raft/core/device_setter.hpp>
 #include <raft/core/memory_tracking_resources.hpp>
@@ -24,28 +26,6 @@
 #include <thread>
 
 namespace {
-
-struct device_resource_restore_guard {
-  int device_id;
-  raft::mr::device_resource resource;
-
-  ~device_resource_restore_guard()
-  {
-    rmm::mr::set_per_device_resource(rmm::cuda_device_id{device_id}, std::move(resource));
-  }
-};
-
-auto current_device_uses_pool_resource() -> bool
-{
-  auto current_mr = rmm::mr::get_current_device_resource_ref();
-  return cuda::mr::resource_cast<rmm::mr::pool_memory_resource>(&current_mr) != nullptr;
-}
-
-auto current_device_uses_default_cuda_resource() -> bool
-{
-  auto current_mr = rmm::mr::get_current_device_resource_ref();
-  return cuda::mr::resource_cast<rmm::mr::cuda_memory_resource>(&current_mr) != nullptr;
-}
 
 TEST(MemoryTrackingResources, TracksDeviceAllocations)
 {
@@ -88,19 +68,8 @@ TEST(MemoryTrackingResources, RestoresDeviceResourceOnConstructionDevice)
   auto device0 = 0;
   auto device1 = 1;
 
-  auto device0_guard = [&]() {
-    auto scoped_device = raft::device_setter{device0};
-    auto upstream      = rmm::mr::get_current_device_resource_ref();
-    return device_resource_restore_guard{
-      device0,
-      rmm::mr::set_current_device_resource(
-        raft::mr::device_resource{rmm::mr::pool_memory_resource(upstream, 1 << 20, 2 << 20)})};
-  }();
-
-  auto device1_guard = [&]() {
-    auto scoped_device = raft::device_setter{device1};
-    return device_resource_restore_guard{device1, rmm::mr::reset_current_device_resource()};
-  }();
+  auto device0_guard = raft::test::install_pool_device_resource(device0);
+  auto device1_guard = raft::test::install_default_device_resource(device1);
 
   {
     auto scoped_device = raft::device_setter{device0};
@@ -133,19 +102,8 @@ TEST(MemoryTrackingResources, InstallsTrackedResourceOnHandleDevice)
   auto device0 = 0;
   auto device1 = 1;
 
-  auto device0_guard = [&]() {
-    auto scoped_device = raft::device_setter{device0};
-    auto upstream      = rmm::mr::get_current_device_resource_ref();
-    return device_resource_restore_guard{
-      device0,
-      rmm::mr::set_current_device_resource(
-        raft::mr::device_resource{rmm::mr::pool_memory_resource(upstream, 1 << 20, 2 << 20)})};
-  }();
-
-  auto device1_guard = [&]() {
-    auto scoped_device = raft::device_setter{device1};
-    return device_resource_restore_guard{device1, rmm::mr::reset_current_device_resource()};
-  }();
+  auto device0_guard = raft::test::install_pool_device_resource(device0);
+  auto device1_guard = raft::test::install_default_device_resource(device1);
 
   {
     auto scoped_device = raft::device_setter{device0};
@@ -159,12 +117,12 @@ TEST(MemoryTrackingResources, InstallsTrackedResourceOnHandleDevice)
 
     {
       auto verify_device0 = raft::device_setter{device0};
-      EXPECT_FALSE(current_device_uses_pool_resource());
+      EXPECT_FALSE(raft::test::current_device_uses_pool_resource());
     }
 
     {
       auto verify_device1 = raft::device_setter{device1};
-      EXPECT_TRUE(current_device_uses_default_cuda_resource());
+      EXPECT_TRUE(raft::test::current_device_uses_default_cuda_resource());
     }
 
     tracked.reset();
@@ -172,12 +130,12 @@ TEST(MemoryTrackingResources, InstallsTrackedResourceOnHandleDevice)
 
   {
     auto scoped_device = raft::device_setter{device0};
-    EXPECT_TRUE(current_device_uses_pool_resource());
+    EXPECT_TRUE(raft::test::current_device_uses_pool_resource());
   }
 
   {
     auto scoped_device = raft::device_setter{device1};
-    EXPECT_TRUE(current_device_uses_default_cuda_resource());
+    EXPECT_TRUE(raft::test::current_device_uses_default_cuda_resource());
   }
 }
 

--- a/cpp/tests/core/monitor_resources.cu
+++ b/cpp/tests/core/monitor_resources.cu
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -13,6 +13,7 @@
 #include <rmm/mr/pool_memory_resource.hpp>
 
 #include <cuda/memory_resource>
+
 #include <gtest/gtest.h>
 
 #include <algorithm>
@@ -104,7 +105,7 @@ TEST(MemoryTrackingResources, RestoresDeviceResourceOnConstructionDevice)
   {
     auto scoped_device = raft::device_setter{device0};
     std::ostringstream oss;
-    auto tracked = std::make_unique<raft::memory_tracking_resources>(oss);
+    auto tracked      = std::make_unique<raft::memory_tracking_resources>(oss);
     auto wrong_device = raft::device_setter{device1};
     static_cast<void>(wrong_device);
     tracked.reset();

--- a/cpp/tests/core/test_memory_resource.hpp
+++ b/cpp/tests/core/test_memory_resource.hpp
@@ -1,0 +1,68 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#pragma once
+
+#include <raft/core/device_setter.hpp>
+#include <raft/mr/host_device_resource.hpp>
+
+#include <rmm/mr/cuda_memory_resource.hpp>
+#include <rmm/mr/per_device_resource.hpp>
+#include <rmm/mr/pool_memory_resource.hpp>
+
+#include <cuda/memory_resource>
+
+#include <gtest/gtest.h>
+
+#include <exception>
+#include <utility>
+
+namespace raft::test {
+
+struct device_resource_restore_guard {
+  int device_id;
+  raft::mr::device_resource resource;
+
+  ~device_resource_restore_guard()
+  {
+    try {
+      rmm::mr::set_per_device_resource(rmm::cuda_device_id{device_id}, std::move(resource));
+    } catch (const std::exception& e) {
+      ADD_FAILURE() << "Failed to restore device " << device_id << " memory resource: " << e.what();
+    } catch (...) {
+      ADD_FAILURE() << "Failed to restore device " << device_id
+                    << " memory resource: unknown exception";
+    }
+  }
+};
+
+inline auto install_pool_device_resource(int device_id) -> device_resource_restore_guard
+{
+  auto scoped_device = raft::device_setter{device_id};
+  auto upstream      = rmm::mr::get_current_device_resource_ref();
+  auto installed_resource =
+    raft::mr::device_resource{rmm::mr::pool_memory_resource(upstream, 1 << 20, 2 << 20)};
+  auto old_resource = rmm::mr::set_current_device_resource(std::move(installed_resource));
+  return device_resource_restore_guard{device_id, std::move(old_resource)};
+}
+
+inline auto install_default_device_resource(int device_id) -> device_resource_restore_guard
+{
+  auto scoped_device = raft::device_setter{device_id};
+  return device_resource_restore_guard{device_id, rmm::mr::reset_current_device_resource()};
+}
+
+inline auto current_device_uses_pool_resource() -> bool
+{
+  auto current_mr = rmm::mr::get_current_device_resource_ref();
+  return cuda::mr::resource_cast<rmm::mr::pool_memory_resource>(&current_mr) != nullptr;
+}
+
+inline auto current_device_uses_default_cuda_resource() -> bool
+{
+  auto current_mr = rmm::mr::get_current_device_resource_ref();
+  return cuda::mr::resource_cast<rmm::mr::cuda_memory_resource>(&current_mr) != nullptr;
+}
+
+}  // namespace raft::test


### PR DESCRIPTION
## Summary
- restore `memory_stats_resources` and `memory_tracking_resources` device memory resources to the CUDA device they wrapped at construction time
- switch the destructor restore path to `rmm::mr::set_per_device_resource(...)` using the captured device id
- add guarded 2-GPU regressions that destroy each wrapper while a different CUDA device is current

## Why
Both wrappers used `rmm::mr::set_current_device_resource(...)` during teardown. In multi-GPU flows that writes the saved resource into whichever CUDA device is current at destruction time, which can leave the construction device pointing at the tracking adaptor and install the wrong resource on another GPU.

## Impact
This keeps per-device RMM state stable across wrapper teardown and closes a nasty multi-GPU correctness hole that could otherwise lead to wrong-device allocators being reused.

## Validation
- `git diff --check`
- attempted `PARALLEL_LEVEL=8 ./build.sh tests -n --limit-tests=CORE_TEST`
- local build is currently blocked by missing `nvcc` / `CUDAToolkit_ROOT`, so the new tests were not run here
