### PR TITLE
X-ORG-3107: Publish API docs to docs.nvidia.com

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -109,6 +109,27 @@ jobs:
       node_type: "gpu-l4-latest-1"
       script: "ci/build_docs.sh"
       sha: ${{ inputs.sha }}
+  publish-api-docs:
+    if: github.ref_type == 'branch'
+    needs: [docs-build]
+    permissions:
+      contents: read
+      id-token: write
+    secrets:
+      akamai-access-token: ${{ secrets.NVIDIA_DOCS_AKAMAI_ACCESS_TOKEN }}
+      akamai-client-token: ${{ secrets.NVIDIA_DOCS_AKAMAI_CLIENT_TOKEN }}
+      akamai-client-secret: ${{ secrets.NVIDIA_DOCS_AKAMAI_CLIENT_SECRET }}
+      akamai-emails-to-notify: ${{ secrets.NVIDIA_DOCS_AKAMAI_EMAILS_TO_NOTIFY }}
+      akamai-host: ${{ secrets.NVIDIA_DOCS_AKAMAI_HOST }}
+      target-aws-access-key-id: ${{ secrets.NVIDIA_DOCS_AWS_ACCESS_KEY_ID }}
+      target-aws-region: ${{ secrets.NVIDIA_DOCS_AWS_REGION }}
+      target-aws-secret-access-key: ${{ secrets.NVIDIA_DOCS_AWS_SECRET_ACCESS_KEY }}
+      target-s3-bucket: ${{ secrets.NVIDIA_DOCS_S3_BUCKET }}
+    uses: rapidsai/shared-workflows/.github/workflows/publish-api-docs.yaml@main
+    with:
+      docs-projects: raft
+      dry-run: false
+      version-map: ${{ vars.VERSION_MAP }}
   wheel-build-libraft:
     needs: [build-details]
     permissions:

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -20,6 +20,7 @@ jobs:
       - conda-python-build
       - conda-python-tests
       - docs-build
+      - publish-api-docs
       - wheel-build-libraft
       - wheel-build-pylibraft
       - wheel-tests-pylibraft
@@ -318,6 +319,26 @@ jobs:
       arch: "amd64"
       container_image: "rapidsai/ci-conda:26.10-latest"
       script: "ci/build_docs.sh"
+  publish-api-docs:
+    needs: [docs-build]
+    permissions:
+      contents: read
+      id-token: write
+    secrets:
+      akamai-access-token: ${{ secrets.NVIDIA_DOCS_AKAMAI_ACCESS_TOKEN }}
+      akamai-client-token: ${{ secrets.NVIDIA_DOCS_AKAMAI_CLIENT_TOKEN }}
+      akamai-client-secret: ${{ secrets.NVIDIA_DOCS_AKAMAI_CLIENT_SECRET }}
+      akamai-emails-to-notify: ${{ secrets.NVIDIA_DOCS_AKAMAI_EMAILS_TO_NOTIFY }}
+      akamai-host: ${{ secrets.NVIDIA_DOCS_AKAMAI_HOST }}
+      target-aws-access-key-id: ${{ secrets.NVIDIA_DOCS_AWS_ACCESS_KEY_ID }}
+      target-aws-region: ${{ secrets.NVIDIA_DOCS_AWS_REGION }}
+      target-aws-secret-access-key: ${{ secrets.NVIDIA_DOCS_AWS_SECRET_ACCESS_KEY }}
+      target-s3-bucket: ${{ secrets.NVIDIA_DOCS_S3_BUCKET }}
+    uses: rapidsai/shared-workflows/.github/workflows/publish-api-docs.yaml@main
+    with:
+      docs-projects: raft
+      dry-run: true
+      version-map: ${{ vars.VERSION_MAP }}
   wheel-build-libraft:
     needs: [build-details, checks]
     permissions:

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -121,8 +121,13 @@ html_theme_options = {
             "type": "fontawesome",
         },
     ],
-    "show_toc_level": 1,
     "navbar_align": "right",
+    "navbar_center": "navbar-nav, version-switcher, navbar-external-links",
+    "show_toc_level": 1,
+    "switcher": {
+        "json_url": "https://docs.nvidia.com/raft/versions.json",
+        "version_match": version,
+    },
 }
 
 # Add any paths that contain custom static files (such as style sheets) here,


### PR DESCRIPTION
Closes #3107

In order to publish docs to docs.nvidia.com, we need to:
- Integrate a [new shared workflow](https://github.com/rapidsai/shared-workflows/blob/main/.github/workflows/publish-api-docs.yaml) for pushing to the docs.nvidia.com S3 bucket
- Activate the version switcher drop-down in Sphinx, using a `versions.json` file located on docs.nvidia.com

N.B.:
- This _does not replace_ publishing docs to docs.rapidsai.org. This is _in addition to_.
- Virtually identical changes have already been made for cudf, cugraph, cuvs, nvforest, rmm, etc.
- Unlike the initial batch of repos, I'm setting the `version-map` parameter via `vars` rather than hard-coding. I'll migrate the initial batch of repos to use this same pattern in the near future so we can coordinate versions independent of code changes.