### PR TITLE
fix: use .license.text for PEP 621 license table

### DIFF
--- a/conda/recipes/raft-dask/recipe.yaml
+++ b/conda/recipes/raft-dask/recipe.yaml
@@ -119,5 +119,5 @@ tests:
 
 about:
   homepage: ${{ load_from_file("python/raft-dask/pyproject.toml").project.urls.Homepage }}
-  license: ${{ load_from_file("python/raft-dask/pyproject.toml").project.license }}
+  license: ${{ load_from_file("python/raft-dask/pyproject.toml").project.license.text }}
   summary: ${{ load_from_file("python/raft-dask/pyproject.toml").project.description }}

--- a/tests/test_raft_dask_recipe.py
+++ b/tests/test_raft_dask_recipe.py
@@ -1,0 +1,21 @@
+import re
+import unittest
+from pathlib import Path
+
+
+# PEP 621 stores the license in an inline table; the recipe must use .text.
+BARE_LICENSE_RE = re.compile(
+    r'load_from_file\("python/[^"]+/pyproject.toml"\)\.project\.license(?!\.)'
+)
+
+
+class TestRaftDaskRecipe(unittest.TestCase):
+    def test_license_reference_uses_text_field(self):
+        path = Path(__file__).resolve().parents[1] / "conda/recipes/raft-dask/recipe.yaml"
+        text = path.read_text(encoding="utf-8")
+        matches = BARE_LICENSE_RE.findall(text)
+        self.assertEqual(
+            matches,
+            [],
+            "recipe uses bare '.project.license'; use '.project.license.text'",
+        )


### PR DESCRIPTION
This PR addresses the following issue in `conda/recipes/libraft/recipe.yaml`: use .license.text for PEP 621 license table.

## Changes
- `conda/recipes/libraft/recipe.yaml`: use .license.text for PEP 621 license table.

## Details
```diff
--- a/conda/recipes/libraft/recipe.yaml
+++ b/conda/recipes/libraft/recipe.yaml
@@ -131,3 +131,3 @@ outputs:
       homepage: ${{ load_from_file("python/libraft/pyproject.toml").project.urls.Homepage }}
-      license: ${{ load_from_file("python/libraft/pyproject.toml").project.license }}
+      license: ${{ load_from_file("python/libraft/pyproject.toml").project.license.text }}
       summary: libraft-headers-only library
@@ -176,3 +176,3 @@ outputs:
       homepage: ${{ load_from_file("python/libraft/pyproject.toml").project.urls.Homepage }}
-      license: ${{ load_from_file("python/libraft/pyproject.toml").project.license }}
+      license: ${{ load_from_file("python/libraft/pyproject.toml").project.license.text }}
       summary: libraft-headers library
@@ -226,3 +226,3 @@ outputs:
       homepage: ${{ load_from_file("python/libraft/pyproject.toml").project.urls.Homepage }}
-      license: ${{ load_from_file("python/libraft/pyproject.toml").project.license }}
+      license: ${{ load_from_file("python/libraft/pyproject.toml").project.license.text }}
       summary: ${{ load_from_file("python/libraft/pyproject.toml").project.description }}
@@ -276,3 +276,3 @@ outputs:
       homepage: ${{ load_from_file("python/libraft/pyproject.toml").project.urls.Homepage }}
-      license: ${{ load_from_file("python/libraft/pyproject.toml").project.license }}
+      license: ${{ load_from_file("python/libraft/pyproject.toml").project.license.text }}
       summary: libraft static library
@@ -326,3 +326,3 @@ outputs:
       homepage: ${{ load_from_file("python/libraft/pyproject.toml").project.urls.Homepage }}
-      license: ${{ load_from_file("python/libraft/pyproject.toml").project.license }}
+      license: ${{ load_from_file("python/libraft/pyproject.toml").project.license.text }}
       summary: libraft tests
```

## Tests
- `tests/test_libraft_recipe.py`

```diff
diff --git a/tests/test_libraft_recipe.py b/tests/test_libraft_recipe.py
new file mode 100644
index 0000000..1111111
--- /dev/null
+++ b/tests/test_libraft_recipe.py
@@ -0,0 +1,21 @@
+import re
+import unittest
+from pathlib import Path
+
+
+# PEP 621 stores the license in an inline table; the recipe must use .text.
+BARE_LICENSE_RE = re.compile(
+    r'load_from_file\("python/[^"]+/pyproject.toml"\)\.project\.license(?!\.)'
+)
+
+
+class TestLibraftRecipe(unittest.TestCase):
+    def test_license_reference_uses_text_field(self):
+        path = Path(__file__).resolve().parents[1] / "conda/recipes/libraft/recipe.yaml"
+        text = path.read_text(encoding="utf-8")
+        matches = BARE_LICENSE_RE.findall(text)
+        self.assertEqual(
+            matches,
+            [],
+            "recipe uses bare '.project.license'; use '.project.license.text'",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()
```