### PR TITLE
fix: libraft output declares unused C compiler

### DIFF
--- a/conda/recipes/libraft/recipe.yaml
+++ b/conda/recipes/libraft/recipe.yaml
@@ -190,7 +190,6 @@ outputs:
     requirements:
       build:
         - cmake ${{ cmake_version }}
-        - ${{ compiler("c") }}
       host:
         - ${{ pin_subpackage("libraft-headers", exact=True) }}
         - cuda-version =${{ cuda_version }}


### PR DESCRIPTION
This PR addresses the following issue in `conda/recipes/libraft/recipe.yaml`: libraft output declares unused C compiler.

## Changes
- `conda/recipes/libraft/recipe.yaml`: libraft output declares unused C compiler.

## Details
```diff
--- a/conda/recipes/libraft/recipe.yaml
+++ b/conda/recipes/libraft/recipe.yaml
@@ -1,16 +1,15 @@
-  - package:
-      name: libraft
-      version: ${{ version }}
-    build:
-      string: cuda${{ cuda_major }}_${{ datetime_string }}_${{ head_rev }}
-      dynamic_linking:
-        overlinking_behavior: "error"
-      script:
-        content: |
-          cmake --install cpp/build --component compiled
-    requirements:
-      build:
-        - cmake ${{ cmake_version }}
-        - ${{ compiler("c") }}
-      host:
-        - ${{ pin_subpackage("libraft-headers", exact=True) }}
+  - package:
+      name: libraft
+      version: ${{ version }}
+    build:
+      string: cuda${{ cuda_major }}_${{ datetime_string }}_${{ head_rev }}
+      dynamic_linking:
+        overlinking_behavior: "error"
+      script:
+        content: |
+          cmake --install cpp/build --component compiled
+    requirements:
+      build:
+        - cmake ${{ cmake_version }}
+      host:
+        - ${{ pin_subpackage("libraft-headers", exact=True) }}
```

## Tests

> Let me know if you want tests added for this fix or not.