### PR TITLE
Lanczos dense fallback on `n <= 3`

### DIFF
--- a/cpp/include/raft/sparse/convert/dense.cuh
+++ b/cpp/include/raft/sparse/convert/dense.cuh
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 #ifndef __DENSE_H
@@ -8,6 +8,8 @@
 #pragma once
 
 #include <raft/core/detail/macros.hpp>
+#include <raft/core/device_mdspan.hpp>
+#include <raft/core/resources.hpp>
 #include <raft/sparse/convert/detail/dense.cuh>
 
 namespace raft {
@@ -15,39 +17,28 @@ namespace sparse {
 namespace convert {
 
 /**
- * Convert CSR arrays to a dense matrix in either row-
- * or column-major format. A custom kernel is used when
- * row-major output is desired since cusparse does not
- * output row-major.
- * @tparam value_idx : data type of the CSR index arrays
- * @tparam value_t : data type of the CSR value array
- * @param[in] handle : cusparse handle for conversion
- * @param[in] nrows : number of rows in CSR
- * @param[in] ncols : number of columns in CSR
- * @param[in] nnz : number of nonzeros in CSR
- * @param[in] csr_indptr : CSR row index pointer array
- * @param[in] csr_indices : CSR column indices array
- * @param[in] csr_data : CSR data array
- * @param[in] lda : Leading dimension (used for col-major only)
- * @param[out] out : Dense output array of size nrows * ncols
- * @param[in] stream : Cuda stream for ordering events
- * @param[in] row_major : Is row-major output desired?
+ * Convert a sparse matrix view to a dense matrix view.
+ *
+ * Supports both COO and CSR sparse matrix views and row- or column-major dense output.
+ *
+ * @param[in] handle RAFT resources
+ * @param[in] sparse Sparse COO or CSR matrix view
+ * @param[out] dense Dense matrix view
  */
-template <typename value_idx, typename value_t>
-void csr_to_dense(cusparseHandle_t handle,
-                  value_idx nrows,
-                  value_idx ncols,
-                  value_idx nnz,
-                  const value_idx* csr_indptr,
-                  const value_idx* csr_indices,
-                  const value_t* csr_data,
-                  value_idx lda,
-                  value_t* out,
-                  cudaStream_t stream,
-                  bool row_major = true)
+template <typename SparseMatrixViewType,
+          typename ValueType,
+          typename IndexType,
+          typename LayoutPolicy>
+void sparse_to_dense(raft::resources const& handle,
+                     SparseMatrixViewType sparse,
+                     raft::device_matrix_view<ValueType, IndexType, LayoutPolicy> dense)
 {
-  detail::csr_to_dense<value_idx, value_t>(
-    handle, nrows, ncols, nnz, csr_indptr, csr_indices, csr_data, lda, out, stream, row_major);
+  auto structure = sparse.structure_view();
+  RAFT_EXPECTS(dense.extent(0) == static_cast<IndexType>(structure.get_n_rows()) &&
+                 dense.extent(1) == static_cast<IndexType>(structure.get_n_cols()),
+               "Sparse and dense matrix dimensions must match");
+
+  detail::sparse_to_dense(handle, sparse, dense);
 }
 
 };  // end NAMESPACE convert

--- a/cpp/include/raft/sparse/convert/detail/dense.cuh
+++ b/cpp/include/raft/sparse/convert/detail/dense.cuh
@@ -6,134 +6,52 @@
 #pragma once
 
 #include <raft/core/detail/macros.hpp>
+#include <raft/core/device_mdarray.hpp>
+#include <raft/core/device_mdspan.hpp>
+#include <raft/core/resource/cuda_stream.hpp>
+#include <raft/core/resource/cusparse_handle.hpp>
+#include <raft/core/resources.hpp>
 #include <raft/sparse/detail/cusparse_wrappers.h>
-#include <raft/sparse/detail/utils.h>
-#include <raft/util/cuda_utils.cuh>
-#include <raft/util/cudart_utils.hpp>
-#include <raft/util/kernel_launch.hpp>
-
-#include <rmm/device_uvector.hpp>
+#include <raft/sparse/linalg/detail/cusparse_utils.hpp>
 
 #include <cuda_runtime.h>
-#include <thrust/device_ptr.h>
-#include <thrust/scan.h>
 
 #include <cusparse_v2.h>
-#include <stdio.h>
-
-#include <algorithm>
-#include <iostream>
 
 namespace raft {
 namespace sparse {
 namespace convert {
 namespace detail {
 
-template <typename value_t>
-RAFT_KERNEL csr_to_dense_warp_per_row_kernel(
-  int n_cols, const value_t* csrVal, const int* csrRowPtr, const int* csrColInd, value_t* a)
+template <typename SparseMatrixViewType,
+          typename ValueType,
+          typename IndexType,
+          typename LayoutPolicy>
+void sparse_to_dense(raft::resources const& handle,
+                     SparseMatrixViewType sparse,
+                     raft::device_matrix_view<ValueType, IndexType, LayoutPolicy> dense)
 {
-  int row = blockIdx.x;
-  int tid = threadIdx.x;
+  auto stream            = raft::resource::get_cuda_stream(handle);
+  auto cusparse_handle   = raft::resource::get_cusparse_handle(handle);
+  auto sparse_descriptor = raft::sparse::linalg::detail::create_descriptor(sparse);
+  auto dense_descriptor  = raft::sparse::linalg::detail::create_descriptor(dense);
 
-  int colStart = csrRowPtr[row];
-  int colEnd   = csrRowPtr[row + 1];
-  int rowNnz   = colEnd - colStart;
+  RAFT_CUSPARSE_TRY(cusparseSetStream(cusparse_handle, stream));
+  std::size_t buffer_size;
+  RAFT_CUSPARSE_TRY(cusparseSparseToDense_bufferSize(cusparse_handle,
+                                                     sparse_descriptor,
+                                                     dense_descriptor,
+                                                     CUSPARSE_SPARSETODENSE_ALG_DEFAULT,
+                                                     &buffer_size));
+  auto buffer = raft::make_device_vector<char, std::size_t>(handle, buffer_size);
+  RAFT_CUSPARSE_TRY(cusparseSparseToDense(cusparse_handle,
+                                          sparse_descriptor,
+                                          dense_descriptor,
+                                          CUSPARSE_SPARSETODENSE_ALG_DEFAULT,
+                                          buffer.data_handle()));
 
-  for (int i = tid; i < rowNnz; i += blockDim.x) {
-    int colIdx = colStart + i;
-    if (colIdx < colEnd) {
-      int col               = csrColInd[colIdx];
-      a[row * n_cols + col] = csrVal[colIdx];
-    }
-  }
-}
-
-/**
- * Convert CSR arrays to a dense matrix in either row-
- * or column-major format. A custom kernel is used when
- * row-major output is desired since cusparse does not
- * output row-major.
- * @tparam value_idx : data type of the CSR index arrays
- * @tparam value_t : data type of the CSR value array
- * @param[in] handle : cusparse handle for conversion
- * @param[in] nrows : number of rows in CSR
- * @param[in] ncols : number of columns in CSR
- * @param[in] nnz : the number of nonzeros in CSR
- * @param[in] csr_indptr : CSR row index pointer array
- * @param[in] csr_indices : CSR column indices array
- * @param[in] csr_data : CSR data array
- * @param[in] lda : Leading dimension (used for col-major only)
- * @param[out] out : Dense output array of size nrows * ncols
- * @param[in] stream : Cuda stream for ordering events
- * @param[in] row_major : Is row-major output desired?
- */
-template <typename value_idx, typename value_t>
-void csr_to_dense(cusparseHandle_t handle,
-                  value_idx nrows,
-                  value_idx ncols,
-                  value_idx nnz,
-                  const value_idx* csr_indptr,
-                  const value_idx* csr_indices,
-                  const value_t* csr_data,
-                  value_idx lda,
-                  value_t* out,
-                  cudaStream_t stream,
-                  bool row_major = true)
-{
-  if (!row_major) {
-    /**
-     * If we need col-major, use cusparse.
-     */
-    cusparseMatDescr_t out_mat;
-    RAFT_CUSPARSE_TRY(cusparseCreateMatDescr(&out_mat));
-    RAFT_CUSPARSE_TRY(cusparseSetMatIndexBase(out_mat, CUSPARSE_INDEX_BASE_ZERO));
-    RAFT_CUSPARSE_TRY(cusparseSetMatType(out_mat, CUSPARSE_MATRIX_TYPE_GENERAL));
-
-    size_t buffer_size;
-    RAFT_CUSPARSE_TRY(raft::sparse::detail::cusparsecsr2dense_buffersize(handle,
-                                                                         nrows,
-                                                                         ncols,
-                                                                         nnz,
-                                                                         out_mat,
-                                                                         csr_data,
-                                                                         csr_indptr,
-                                                                         csr_indices,
-                                                                         out,
-                                                                         lda,
-                                                                         &buffer_size,
-                                                                         stream));
-
-    rmm::device_uvector<char> buffer(buffer_size, stream);
-
-    RAFT_CUSPARSE_TRY(raft::sparse::detail::cusparsecsr2dense(handle,
-                                                              nrows,
-                                                              ncols,
-                                                              nnz,
-                                                              out_mat,
-                                                              csr_data,
-                                                              csr_indptr,
-                                                              csr_indices,
-                                                              out,
-                                                              lda,
-                                                              buffer.data(),
-                                                              stream));
-
-    RAFT_CUSPARSE_TRY_NO_THROW(cusparseDestroyMatDescr(out_mat));
-
-  } else {
-    int blockdim = block_dim(ncols);
-    RAFT_CUDA_TRY(cudaMemsetAsync(out, 0, nrows * ncols * sizeof(value_t), stream));
-    raft::launch_kernel(stream,
-                        nrows,
-                        blockdim,
-                        csr_to_dense_warp_per_row_kernel,
-                        ncols,
-                        csr_data,
-                        csr_indptr,
-                        csr_indices,
-                        out);
-  }
+  RAFT_CUSPARSE_TRY_NO_THROW(cusparseDestroySpMat(sparse_descriptor));
+  RAFT_CUSPARSE_TRY_NO_THROW(cusparseDestroyDnMat(dense_descriptor));
 }
 
 };  // namespace detail

--- a/cpp/include/raft/sparse/solver/detail/lanczos.cuh
+++ b/cpp/include/raft/sparse/solver/detail/lanczos.cuh
@@ -18,6 +18,8 @@
 #include <raft/core/mdspan_types.hpp>
 #include <raft/core/resource/cublas_handle.hpp>
 #include <raft/core/resource/cuda_stream.hpp>
+#include <raft/core/resource/cusparse_handle.hpp>
+#include <raft/core/resource/thrust_policy.hpp>
 #include <raft/core/resources.hpp>
 #include <raft/core/types.hpp>
 #include <raft/linalg/add.cuh>
@@ -44,6 +46,7 @@
 #include <raft/matrix/slice.cuh>
 #include <raft/matrix/triangular.cuh>
 #include <raft/random/rng.cuh>
+#include <raft/sparse/convert/dense.cuh>
 #include <raft/sparse/detail/cusparse_wrappers.h>
 #include <raft/sparse/linalg/detail/cusparse_utils.hpp>
 #include <raft/sparse/solver/lanczos_types.hpp>
@@ -129,9 +132,7 @@ RAFT_KERNEL kernel_clamp_down_vector(T* vec, T threshold, int size)
 template <typename IndexTypeT, typename ValueTypeT>
 void lanczos_solve_ritz(
   raft::resources const& handle,
-  raft::device_matrix_view<ValueTypeT, uint32_t, raft::row_major> alpha,
-  raft::device_matrix_view<ValueTypeT, uint32_t, raft::row_major> beta,
-  std::optional<raft::device_vector_view<ValueTypeT, uint32_t>> beta_k,
+  raft::device_matrix_view<const ValueTypeT, uint32_t, raft::col_major> matrix,
   IndexTypeT k,
   LANCZOS_WHICH which,
   int ncv,
@@ -145,46 +146,7 @@ void lanczos_solve_ritz(
 {
   auto stream = resource::get_cuda_stream(handle);
 
-  ValueTypeT zero = 0;
-  auto triangular_matrix =
-    raft::make_device_matrix<ValueTypeT, uint32_t, raft::col_major>(handle, ncv, ncv);
-  raft::matrix::fill(handle, triangular_matrix.view(), zero);
-
-  raft::device_vector_view<const ValueTypeT, uint32_t> alphaVec =
-    raft::make_device_vector_view<const ValueTypeT, uint32_t>(alpha.data_handle(), ncv);
-  raft::matrix::set_diagonal(handle, alphaVec, triangular_matrix.view());
-
-  // raft::matrix::initializeDiagonalMatrix(
-  //   alpha.data_handle(), triangular_matrix.data_handle(), ncv, ncv, stream);
-
-  int blockSize = 256;
-  int numBlocks = raft::div_rounding_up_safe(ncv, blockSize);
-  raft::launch_kernel(handle,
-                      numBlocks,
-                      blockSize,
-                      kernel_triangular_populate<ValueTypeT>,
-                      triangular_matrix.data_handle(),
-                      beta.data_handle(),
-                      ncv);
-
-  if (beta_k) {
-    int threadsPerBlock = 256;
-    int blocksPerGrid   = raft::div_rounding_up_safe<int>(k, threadsPerBlock);
-    raft::launch_kernel(handle,
-                        blocksPerGrid,
-                        threadsPerBlock,
-                        kernel_triangular_beta_k<ValueTypeT>,
-                        triangular_matrix.data_handle(),
-                        beta_k.value().data_handle(),
-                        k,
-                        ncv);
-  }
-
-  auto triangular_matrix_view =
-    raft::make_device_matrix_view<const ValueTypeT, uint32_t, raft::col_major>(
-      triangular_matrix.data_handle(), ncv, ncv);
-
-  raft::linalg::eig_dc(handle, triangular_matrix_view, eigenvectors, eigenvalues);
+  raft::linalg::eig_dc(handle, matrix, eigenvectors, eigenvalues);
 
   IndexTypeT nEigVecs = k;
 
@@ -254,6 +216,76 @@ void lanczos_solve_ritz(
     eigenvectors_k_slice = raft::make_device_matrix_view<ValueTypeT, IndexTypeT, raft::col_major>(
       sm_eigenvectors.data_handle(), ncv, nEigVecs);
   }
+}
+
+template <typename IndexTypeT, typename ValueTypeT>
+void lanczos_solve_ritz(
+  raft::resources const& handle,
+  raft::device_matrix_view<ValueTypeT, uint32_t, raft::row_major> alpha,
+  raft::device_matrix_view<ValueTypeT, uint32_t, raft::row_major> beta,
+  std::optional<raft::device_vector_view<ValueTypeT, uint32_t>> beta_k,
+  IndexTypeT k,
+  LANCZOS_WHICH which,
+  int ncv,
+  raft::device_matrix_view<ValueTypeT, uint32_t, raft::col_major> eigenvectors,
+  raft::device_vector_view<ValueTypeT> eigenvalues,
+  raft::device_matrix_view<ValueTypeT, uint32_t, raft::col_major>& eigenvectors_k,
+  raft::device_vector_view<ValueTypeT, uint32_t>& eigenvalues_k,
+  raft::device_matrix_view<ValueTypeT, IndexTypeT, raft::col_major>& eigenvectors_k_slice,
+  raft::device_vector_view<ValueTypeT> sm_eigenvalues,
+  raft::device_matrix_view<ValueTypeT, uint32_t, raft::col_major> sm_eigenvectors)
+{
+  ValueTypeT zero = 0;
+  auto triangular_matrix =
+    raft::make_device_matrix<ValueTypeT, uint32_t, raft::col_major>(handle, ncv, ncv);
+  raft::matrix::fill(handle, triangular_matrix.view(), zero);
+
+  raft::device_vector_view<const ValueTypeT, uint32_t> alphaVec =
+    raft::make_device_vector_view<const ValueTypeT, uint32_t>(alpha.data_handle(), ncv);
+  raft::matrix::set_diagonal(handle, alphaVec, triangular_matrix.view());
+
+  // raft::matrix::initializeDiagonalMatrix(
+  //   alpha.data_handle(), triangular_matrix.data_handle(), ncv, ncv, stream);
+
+  int blockSize = 256;
+  int numBlocks = raft::div_rounding_up_safe(ncv, blockSize);
+  raft::launch_kernel(handle,
+                      numBlocks,
+                      blockSize,
+                      kernel_triangular_populate<ValueTypeT>,
+                      triangular_matrix.data_handle(),
+                      beta.data_handle(),
+                      ncv);
+
+  if (beta_k) {
+    int threadsPerBlock = 256;
+    int blocksPerGrid   = raft::div_rounding_up_safe<int>(k, threadsPerBlock);
+    raft::launch_kernel(handle,
+                        blocksPerGrid,
+                        threadsPerBlock,
+                        kernel_triangular_beta_k<ValueTypeT>,
+                        triangular_matrix.data_handle(),
+                        beta_k.value().data_handle(),
+                        k,
+                        ncv);
+  }
+
+  auto triangular_matrix_view =
+    raft::make_device_matrix_view<const ValueTypeT, uint32_t, raft::col_major>(
+      triangular_matrix.data_handle(), ncv, ncv);
+
+  lanczos_solve_ritz<IndexTypeT, ValueTypeT>(handle,
+                                             triangular_matrix_view,
+                                             k,
+                                             which,
+                                             ncv,
+                                             eigenvectors,
+                                             eigenvalues,
+                                             eigenvectors_k,
+                                             eigenvalues_k,
+                                             eigenvectors_k_slice,
+                                             sm_eigenvalues,
+                                             sm_eigenvectors);
 }
 
 template <typename IndexTypeT, typename ValueTypeT, typename AType>
@@ -797,6 +829,46 @@ auto lanczos_compute_eigenpairs(
   raft::device_vector_view<ValueTypeT, uint32_t> eigenvalues,
   raft::device_matrix_view<ValueTypeT, uint32_t, raft::col_major> eigenvectors) -> int
 {
+  auto stream = resource::get_cuda_stream(handle);
+  auto n      = A.structure_view().get_n_rows();
+  RAFT_EXPECTS(config.n_components > 0 && config.n_components < n,
+               "n_components must satisfy 0 < n_components < n");
+
+  if (n <= 3) {
+    auto k = config.n_components;
+    auto dense_matrix =
+      raft::make_device_matrix<ValueTypeT, uint32_t, raft::col_major>(handle, n, n);
+    auto all_eigenvectors =
+      raft::make_device_matrix<ValueTypeT, uint32_t, raft::col_major>(handle, n, n);
+    auto all_eigenvalues = raft::make_device_vector<ValueTypeT, uint32_t>(handle, n);
+    auto sm_eigenvectors =
+      raft::make_device_matrix<ValueTypeT, uint32_t, raft::col_major>(handle, n, k);
+    auto sm_eigenvalues = raft::make_device_vector<ValueTypeT, uint32_t>(handle, k);
+    raft::device_matrix_view<ValueTypeT, uint32_t, raft::col_major> eigenvectors_k;
+    raft::device_vector_view<ValueTypeT, uint32_t> eigenvalues_k;
+    raft::device_matrix_view<ValueTypeT, IndexTypeT, raft::col_major> eigenvectors_k_slice;
+
+    raft::sparse::convert::sparse_to_dense(handle, A, dense_matrix.view());
+    lanczos_solve_ritz<IndexTypeT, ValueTypeT>(handle,
+                                               raft::make_const_mdspan(dense_matrix.view()),
+                                               k,
+                                               config.which,
+                                               n,
+                                               all_eigenvectors.view(),
+                                               all_eigenvalues.view(),
+                                               eigenvectors_k,
+                                               eigenvalues_k,
+                                               eigenvectors_k_slice,
+                                               sm_eigenvalues.view(),
+                                               sm_eigenvectors.view());
+    raft::copy(eigenvalues.data_handle(), eigenvalues_k.data_handle(), k, stream);
+    raft::copy(eigenvectors.data_handle(), eigenvectors_k.data_handle(), n * k, stream);
+    return 0;
+  }
+
+  RAFT_EXPECTS(config.ncv > config.n_components + 1 && config.ncv < n,
+               "ncv must satisfy n_components + 1 < ncv < n");
+
   if (v0.has_value()) {
     return lanczos_smallest<IndexTypeT, ValueTypeT, AType>(handle,
                                                            A,
@@ -811,7 +883,6 @@ auto lanczos_compute_eigenpairs(
                                                            config.seed);
   } else {
     // Handle the optional v0 initial Lanczos vector if nullopt is used
-    auto n        = A.structure_view().get_n_rows();
     auto temp_v0  = raft::make_device_vector<ValueTypeT, uint32_t>(handle, n);
     uint64_t seed = config.seed.value_or(std::random_device{}());
     raft::random::RngState rng_state(seed);

--- a/cpp/tests/sparse/csr_to_dense.cu
+++ b/cpp/tests/sparse/csr_to_dense.cu
@@ -1,19 +1,18 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2018-2024, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2018-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
 #include "../test_utils.cuh"
 
+#include <raft/core/device_csr_matrix.hpp>
 #include <raft/core/resource/cuda_stream.hpp>
 #include <raft/core/resources.hpp>
 #include <raft/sparse/convert/dense.cuh>
-#include <raft/sparse/detail/cusparse_wrappers.h>
 #include <raft/util/cudart_utils.hpp>
 
 #include <rmm/device_uvector.hpp>
 
-#include <cusparse_v2.h>
 #include <gtest/gtest.h>
 
 namespace raft {
@@ -79,24 +78,17 @@ class CSRToDenseTest : public ::testing::TestWithParam<CSRToDenseInputs<value_id
 
   void SetUp() override
   {
-    RAFT_CUSPARSE_TRY(cusparseCreate(&handle));
-
     make_data();
 
-    convert::csr_to_dense(handle,
-                          params.nrows,
-                          params.ncols,
-                          params.nnz,
-                          indptr.data(),
-                          indices.data(),
-                          data.data(),
-                          params.nrows,
-                          out.data(),
-                          stream,
-                          true);
+    auto structure = raft::make_device_compressed_structure_view<value_idx, value_idx, value_idx>(
+      indptr.data(), indices.data(), params.nrows, params.ncols, params.nnz);
+    auto csr = raft::make_device_csr_matrix_view<value_t, value_idx, value_idx, value_idx>(
+      data.data(), structure);
+    auto dense = raft::make_device_matrix_view<value_t, value_idx, raft::row_major>(
+      out.data(), params.nrows, params.ncols);
+    convert::sparse_to_dense(raft_handle, csr, dense);
 
     RAFT_CUDA_TRY(cudaStreamSynchronize(stream));
-    RAFT_CUSPARSE_TRY(cusparseDestroy(handle));
   }
 
   void compare()
@@ -108,8 +100,6 @@ class CSRToDenseTest : public ::testing::TestWithParam<CSRToDenseInputs<value_id
  protected:
   raft::resources raft_handle;
   cudaStream_t stream;
-
-  cusparseHandle_t handle;
 
   // input data
   rmm::device_uvector<value_idx> indptr, indices;

--- a/cpp/tests/util/preprocess_utils.cu
+++ b/cpp/tests/util/preprocess_utils.cu
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2025, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -135,32 +135,14 @@ void calc_tfidf_bm25(raft::resources& handle,
   cudaStream_t stream = raft::resource::get_cuda_stream(handle);
   int num_rows        = csr_in.structure_view().get_n_rows();
   int num_cols        = csr_in.structure_view().get_n_cols();
-  int rows_size       = csr_in.structure_view().get_indptr().size();
-  int cols_size       = csr_in.structure_view().get_indices().size();
-  int elements_size   = csr_in.get_elements().size();
 
-  auto indptr = raft::make_device_vector_view<T1, int64_t>(
-    csr_in.structure_view().get_indptr().data(), rows_size);
-  auto indices = raft::make_device_vector_view<T1, int64_t>(
-    csr_in.structure_view().get_indices().data(), cols_size);
-  auto values =
-    raft::make_device_vector_view<T2, int64_t>(csr_in.get_elements().data(), elements_size);
   auto dense_values = raft::make_device_vector<T2, int64_t>(handle, num_rows * num_cols);
 
-  cusparseHandle_t cu_handle;
-  RAFT_CUSPARSE_TRY(cusparseCreate(&cu_handle));
-
-  raft::sparse::convert::csr_to_dense(cu_handle,
-                                      num_rows,
-                                      num_cols,
-                                      elements_size,
-                                      indptr.data_handle(),
-                                      indices.data_handle(),
-                                      values.data_handle(),
-                                      num_rows,
-                                      dense_values.data_handle(),
-                                      stream,
-                                      true);
+  raft::sparse::convert::sparse_to_dense(
+    handle,
+    csr_in,
+    raft::make_device_matrix_view<T2, int64_t, raft::row_major>(
+      dense_values.data_handle(), num_rows, num_cols));
 
   RAFT_CUDA_TRY(cudaStreamSynchronize(stream));
   preproc<T1, T2>(handle, dense_values.view(), results, num_rows, num_cols, tf_idf);


### PR DESCRIPTION
Resolves https://github.com/NVIDIA/cuml/issues/8492

RAFT’s Lanczos solver [requires `n_components + 1 < ncv < n`](https://github.com/NVIDIA/raft/blob/v26.08.00/cpp/include/raft/sparse/solver/lanczos_types.hpp#L49-L52)

However, this isn't enforced so it causes an unexpected segfault instead of a raft error.
This PR adds that check and also adds a dense solver fallback path. This was an opportunity to clean up the sparse_to_dense APIs too.

Marking as breaking since we are removing `csr_to_dense` in favor of `sparse_to_dense` (supports both csr and coo inputs).