### PR TITLE
Fix curand stream ordering in MST alteration

### DIFF
--- a/cpp/include/raft/sparse/solver/detail/mst_solver_inl.cuh
+++ b/cpp/include/raft/sparse/solver/detail/mst_solver_inl.cuh
@@ -225,6 +225,7 @@ void MST_solver<vertex_t, edge_t, weight_t, alteration_t>::alteration()
   // Random number generator
   curandGenerator_t randGen;
   curandCreateGenerator(&randGen, CURAND_RNG_PSEUDO_DEFAULT);
+  curandSetStream(randGen, stream);
   curandSetPseudoRandomGeneratorSeed(randGen, 1234567);
 
   // Initialize rand values


### PR DESCRIPTION
Assign the cuRAND generator used by `MST_solver::alteration()` to the MST CUDA stream.

## Problem

`MST_solver::alteration()` allocates `rand_values` on the supplied stream and launches the alteration kernel on that stream, but the cuRAND generator is left on its default stream.

This permits the following ordering:

1. cuRAND starts writing `rand_values` on stream 0.
2. The alteration kernel starts reading `rand_values` on the MST stream.
3. There is no dependency between those streams.

Under concurrent HDBSCAN workloads using managed memory on GB300, this can eventually surface as an illegal address in a later operation. The downstream error observed by cuML was:

```cpp
copy_if failed on 2nd step: cudaErrorIllegalAddress
```

Related cuML issue: https://github.com/NVIDIA/cuml/issues/8510
Companion cuVS PR: https://github.com/NVIDIA/cuvs/pull/2509