### PR TITLE
Migrate stream APIs from rmm::cuda_stream_view to cuda::stream_ref

### DIFF
--- a/cpp/bench/prims/common/benchmark.hpp
+++ b/cpp/bench/prims/common/benchmark.hpp
@@ -15,11 +15,12 @@
 
 #include <rmm/cuda_device.hpp>
 #include <rmm/cuda_stream.hpp>
-#include <rmm/cuda_stream_view.hpp>
 #include <rmm/device_buffer.hpp>
 #include <rmm/mr/cuda_memory_resource.hpp>
 #include <rmm/mr/per_device_resource.hpp>
 #include <rmm/mr/pool_memory_resource.hpp>
+
+#include <cuda/stream>
 
 #include <benchmark/benchmark.h>
 
@@ -59,7 +60,7 @@ struct using_pool_memory_res {
 struct cuda_event_timer {
  private:
   ::benchmark::State* state_;
-  rmm::cuda_stream_view stream_;
+  cuda::stream_ref stream_;
   cudaEvent_t start_;
   cudaEvent_t stop_;
 
@@ -68,7 +69,7 @@ struct cuda_event_timer {
    * @param state  the benchmark::State whose timer we are going to update.
    * @param stream CUDA stream we are measuring time on.
    */
-  cuda_event_timer(::benchmark::State& state, rmm::cuda_stream_view stream)
+  cuda_event_timer(::benchmark::State& state, cuda::stream_ref stream)
     : state_(&state), stream_(stream)
   {
     RAFT_CUDA_TRY(cudaEventCreate(&start_));
@@ -102,7 +103,7 @@ class fixture {
 
  public:
   raft::device_resources handle;
-  rmm::cuda_stream_view stream;
+  cuda::stream_ref stream;
 
   explicit fixture(bool use_pool_memory_resource = false)
     : stream{resource::get_cuda_stream(handle)}

--- a/cpp/include/raft/comms/detail/mpi_comms.hpp
+++ b/cpp/include/raft/comms/detail/mpi_comms.hpp
@@ -12,8 +12,9 @@
 #include <raft/core/resources.hpp>
 #include <raft/util/cudart_utils.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
 #include <rmm/device_scalar.hpp>
+
+#include <cuda/stream>
 
 #include <mpi.h>
 #include <nccl.h>
@@ -96,7 +97,7 @@ constexpr MPI_Op get_mpi_op(const op_t op)
 
 class mpi_comms : public comms_iface {
  public:
-  mpi_comms(MPI_Comm comm, const bool owns_mpi_comm, rmm::cuda_stream_view stream)
+  mpi_comms(MPI_Comm comm, const bool owns_mpi_comm, cuda::stream_ref stream)
     : owns_mpi_comm_(owns_mpi_comm),
       mpi_comm_(comm),
       size_(0),
@@ -123,10 +124,7 @@ class mpi_comms : public comms_iface {
     initialize();
   }
 
-  mpi_comms(MPI_Comm mpi_comm,
-            bool owns_mpi_comm,
-            ncclComm_t nccl_comm,
-            rmm::cuda_stream_view stream)
+  mpi_comms(MPI_Comm mpi_comm, bool owns_mpi_comm, ncclComm_t nccl_comm, cuda::stream_ref stream)
     : owns_mpi_comm_(owns_mpi_comm),
       mpi_comm_(mpi_comm),
       nccl_comm_(nccl_comm),

--- a/cpp/include/raft/comms/detail/std_comms.hpp
+++ b/cpp/include/raft/comms/detail/std_comms.hpp
@@ -16,6 +16,7 @@
 #include <rmm/device_scalar.hpp>
 #include <rmm/device_uvector.hpp>
 
+#include <cuda/stream>
 #include <cuda_runtime.h>
 #include <thrust/iterator/zip_iterator.h>
 
@@ -69,7 +70,7 @@ class std_comms : public comms_iface {
             ucx_objects_t ucx_objects,
             int num_ranks,
             int rank,
-            rmm::cuda_stream_view stream,
+            cuda::stream_ref stream,
             bool subcomms_ucp = true)
     : nccl_comm_(nccl_comm),
       stream_(stream.get()),
@@ -94,7 +95,7 @@ class std_comms : public comms_iface {
   std_comms(const ncclComm_t nccl_comm,
             int num_ranks,
             int rank,
-            rmm::cuda_stream_view stream,
+            cuda::stream_ref stream,
             bool own_nccl_comm = false)
     : nccl_comm_(nccl_comm),
       stream_(stream.get()),

--- a/cpp/include/raft/core/detail/nvtx.hpp
+++ b/cpp/include/raft/core/detail/nvtx.hpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/cpp/include/raft/core/detail/nvtx.hpp
+++ b/cpp/include/raft/core/detail/nvtx.hpp
@@ -8,8 +8,6 @@
 #include <raft/core/detail/macros.hpp>
 #include <raft/core/detail/nvtx_range_stack.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
-
 #ifdef NVTX_ENABLED
 
 #include <nvtx3/nvToolsExt.h>

--- a/cpp/include/raft/core/device_container_policy.hpp
+++ b/cpp/include/raft/core/device_container_policy.hpp
@@ -20,11 +20,11 @@
 #include <raft/core/resource/device_memory_resource.hpp>
 #include <raft/util/cudart_utils.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
 #include <rmm/device_uvector.hpp>
 #include <rmm/mr/per_device_resource.hpp>
 #include <rmm/resource_ref.hpp>
 
+#include <cuda/stream>
 #include <thrust/device_ptr.h>
 
 namespace RAFT_EXPORT raft {
@@ -43,11 +43,10 @@ class device_reference {
 
  private:
   std::conditional_t<std::is_const<T>::value, const_pointer, pointer> ptr_;
-  rmm::cuda_stream_view stream_;
+  cuda::stream_ref stream_;
 
  public:
-  device_reference(thrust::device_ptr<T> ptr, rmm::cuda_stream_view stream)
-    : ptr_{ptr}, stream_{stream}
+  device_reference(thrust::device_ptr<T> ptr, cuda::stream_ref stream) : ptr_{ptr}, stream_{stream}
   {
   }
 
@@ -103,12 +102,12 @@ class device_uvector {
   /**
    * @brief Ctor that accepts a size, stream and an optional mr.
    */
-  explicit device_uvector(std::size_t size, rmm::cuda_stream_view stream) : data_{size, stream} {}
+  explicit device_uvector(std::size_t size, cuda::stream_ref stream) : data_{size, stream} {}
   /**
    * @brief Ctor that accepts a size, stream and a memory resource.
    */
   explicit device_uvector(std::size_t size,
-                          rmm::cuda_stream_view stream,
+                          cuda::stream_ref stream,
                           rmm::device_async_resource_ref mr)
     : data_{size, stream, mr}
   {

--- a/cpp/include/raft/core/device_resources.hpp
+++ b/cpp/include/raft/core/device_resources.hpp
@@ -159,7 +159,7 @@ class device_resources : public resources {
   /**
    * @brief return stream from pool
    */
-  rmm::cuda_stream_view get_stream_from_stream_pool() const
+  cuda::stream_ref get_stream_from_stream_pool() const
   {
     return resource::get_stream_from_stream_pool(*this);
   }
@@ -167,7 +167,7 @@ class device_resources : public resources {
   /**
    * @brief return stream from pool at index
    */
-  rmm::cuda_stream_view get_stream_from_stream_pool(std::size_t stream_idx) const
+  cuda::stream_ref get_stream_from_stream_pool(std::size_t stream_idx) const
   {
     return resource::get_stream_from_stream_pool(*this, stream_idx);
   }
@@ -175,7 +175,7 @@ class device_resources : public resources {
   /**
    * @brief return stream from pool if size > 0, else main stream on current container
    */
-  rmm::cuda_stream_view get_next_usable_stream() const
+  cuda::stream_ref get_next_usable_stream() const
   {
     return resource::get_next_usable_stream(*this);
   }
@@ -185,7 +185,7 @@ class device_resources : public resources {
    *
    * @param[in] stream_idx the required index of the stream in the stream pool if available
    */
-  rmm::cuda_stream_view get_next_usable_stream(std::size_t stream_idx) const
+  cuda::stream_ref get_next_usable_stream(std::size_t stream_idx) const
   {
     return resource::get_next_usable_stream(*this, stream_idx);
   }

--- a/cpp/include/raft/core/device_resources.hpp
+++ b/cpp/include/raft/core/device_resources.hpp
@@ -76,7 +76,7 @@ class device_resources : public resources {
    * @param[in] allocation_limit the total amount of memory in bytes available to the temporary
    *            workspace resources.
    */
-  device_resources(rmm::cuda_stream_view stream_view = cuda::stream_ref{cudaStreamPerThread},
+  device_resources(cuda::stream_ref stream_view = cuda::stream_ref{cudaStreamPerThread},
                    std::shared_ptr<rmm::cuda_stream_pool> stream_pool          = {nullptr},
                    std::optional<raft::mr::device_resource> workspace_resource = std::nullopt,
                    std::optional<std::size_t> allocation_limit                 = std::nullopt)
@@ -119,7 +119,7 @@ class device_resources : public resources {
    * @param[in] stream stream to synchronize
    * @param[in] location the call site to blame for the errors; leave at its default
    */
-  void sync_stream(rmm::cuda_stream_view stream,
+  void sync_stream(cuda::stream_ref stream,
                    std::source_location location = std::source_location::current()) const
   {
     resource::sync_stream(*this, stream, location);
@@ -138,7 +138,7 @@ class device_resources : public resources {
   /**
    * @brief returns main stream on the current container
    */
-  rmm::cuda_stream_view get_stream() const { return resource::get_cuda_stream(*this); }
+  cuda::stream_ref get_stream() const { return resource::get_cuda_stream(*this); }
 
   /**
    * @brief returns whether stream pool was initialized on the current container

--- a/cpp/include/raft/core/dry_run_resources.hpp
+++ b/cpp/include/raft/core/dry_run_resources.hpp
@@ -16,7 +16,6 @@
 #include <raft/mr/host_device_resource.hpp>
 #include <raft/mr/host_memory_resource.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
 #include <rmm/mr/per_device_resource.hpp>
 #include <rmm/resource_ref.hpp>
 

--- a/cpp/include/raft/core/handle.hpp
+++ b/cpp/include/raft/core/handle.hpp
@@ -43,7 +43,7 @@ class handle_t : public raft::device_resources {
    * @param[in] workspace_resource an optional resource used by some functions for allocating
    *            temporary workspaces.
    */
-  handle_t(rmm::cuda_stream_view stream_view = cuda::stream_ref{cudaStreamPerThread},
+  handle_t(cuda::stream_ref stream_view = cuda::stream_ref{cudaStreamPerThread},
            std::shared_ptr<rmm::cuda_stream_pool> stream_pool          = {nullptr},
            std::optional<raft::mr::device_resource> workspace_resource = std::nullopt)
     : device_resources{stream_view, stream_pool, std::move(workspace_resource)}

--- a/cpp/include/raft/core/interruptible.hpp
+++ b/cpp/include/raft/core/interruptible.hpp
@@ -12,7 +12,7 @@
 #include <raft/core/error.hpp>
 #include <raft/util/cudart_utils.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
+#include <cuda/stream>
 
 #include <atomic>
 #include <memory>
@@ -76,7 +76,7 @@ class interruptible {
    * thread before the currently captured work has been finished.
    * @throw raft::cuda_error if another CUDA error happens.
    */
-  static inline void synchronize(rmm::cuda_stream_view stream,
+  static inline void synchronize(cuda::stream_ref stream,
                                  std::source_location location = std::source_location::current())
   {
     get_token()->synchronize_impl(cudaStreamQuery, stream.get(), "cudaStreamQuery", location);

--- a/cpp/include/raft/core/memory_stats_resources.hpp
+++ b/cpp/include/raft/core/memory_stats_resources.hpp
@@ -14,7 +14,6 @@
 #include <raft/mr/host_memory_resource.hpp>
 #include <raft/mr/statistics_adaptor.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
 #include <rmm/mr/per_device_resource.hpp>
 #include <rmm/resource_ref.hpp>
 

--- a/cpp/include/raft/core/memory_tracking_resources.hpp
+++ b/cpp/include/raft/core/memory_tracking_resources.hpp
@@ -17,7 +17,6 @@
 #include <raft/mr/resource_monitor.hpp>
 #include <raft/mr/statistics_adaptor.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
 #include <rmm/mr/per_device_resource.hpp>
 #include <rmm/resource_ref.hpp>
 

--- a/cpp/include/raft/core/resource/cublas_handle.hpp
+++ b/cpp/include/raft/core/resource/cublas_handle.hpp
@@ -17,7 +17,7 @@ namespace resource {
 
 class cublas_resource : public resource {
  public:
-  cublas_resource(rmm::cuda_stream_view stream)
+  cublas_resource(cuda::stream_ref stream)
   {
     RAFT_CUBLAS_TRY_NO_THROW(cublasCreate(&cublas_res));
     RAFT_CUBLAS_TRY_NO_THROW(cublasSetStream(cublas_res, stream.get()));
@@ -38,12 +38,12 @@ class cublas_resource : public resource {
  */
 class cublas_resource_factory : public resource_factory {
  public:
-  cublas_resource_factory(rmm::cuda_stream_view stream) : stream_(stream) {}
+  cublas_resource_factory(cuda::stream_ref stream) : stream_(stream) {}
   resource_type get_resource_type() override { return resource_type::CUBLAS_HANDLE; }
   resource* make_resource() override { return new cublas_resource(stream_); }
 
  private:
-  rmm::cuda_stream_view stream_;
+  cuda::stream_ref stream_;
 };
 
 /**

--- a/cpp/include/raft/core/resource/cuda_stream.hpp
+++ b/cpp/include/raft/core/resource/cuda_stream.hpp
@@ -11,8 +11,6 @@
 #include <raft/core/resources.hpp>
 #include <raft/util/cudart_utils.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
-
 #include <cuda/stream>
 #include <cuda_runtime.h>
 
@@ -22,7 +20,7 @@ namespace RAFT_EXPORT raft {
 namespace resource {
 class cuda_stream_resource : public resource {
  public:
-  cuda_stream_resource(rmm::cuda_stream_view stream_view = cuda::stream_ref{cudaStreamPerThread})
+  cuda_stream_resource(cuda::stream_ref stream_view = cuda::stream_ref{cudaStreamPerThread})
     : stream(stream_view)
   {
   }
@@ -31,7 +29,7 @@ class cuda_stream_resource : public resource {
   ~cuda_stream_resource() override {}
 
  private:
-  rmm::cuda_stream_view stream;
+  cuda::stream_ref stream;
 };
 
 /**
@@ -40,8 +38,7 @@ class cuda_stream_resource : public resource {
  */
 class cuda_stream_resource_factory : public resource_factory {
  public:
-  cuda_stream_resource_factory(
-    rmm::cuda_stream_view stream_view = cuda::stream_ref{cudaStreamPerThread})
+  cuda_stream_resource_factory(cuda::stream_ref stream_view = cuda::stream_ref{cudaStreamPerThread})
     : stream(stream_view)
   {
   }
@@ -49,7 +46,7 @@ class cuda_stream_resource_factory : public resource_factory {
   resource* make_resource() override { return new cuda_stream_resource(stream); }
 
  private:
-  rmm::cuda_stream_view stream;
+  cuda::stream_ref stream;
 };
 
 /**
@@ -57,26 +54,25 @@ class cuda_stream_resource_factory : public resource_factory {
  * @{
  */
 /**
- * Load a rmm::cuda_stream_view from a resources instance (and populate it on the res
+ * Load a cuda::stream_ref from a resources instance (and populate it on the res
  * if needed).
  * @param res raft res object for managing resources
  * @return
  */
-inline rmm::cuda_stream_view get_cuda_stream(resources const& res)
+inline cuda::stream_ref get_cuda_stream(resources const& res)
 {
   if (!res.has_resource_factory(resource_type::CUDA_STREAM_VIEW)) {
     res.ensure_default_factory(std::make_shared<cuda_stream_resource_factory>());
   }
-  return *res.get_resource<rmm::cuda_stream_view>(resource_type::CUDA_STREAM_VIEW);
+  return *res.get_resource<cuda::stream_ref>(resource_type::CUDA_STREAM_VIEW);
 };
 
 /**
- * Load a rmm::cuda_stream_view from a resources instance (and populate it on the res
- * if needed).
+ * Set a cuda::stream_ref on a resources instance.
  * @param[in] res raft resources object for managing resources
- * @param[in] stream_view cuda stream view
+ * @param[in] stream_view cuda stream reference
  */
-inline void set_cuda_stream(resources& res, rmm::cuda_stream_view stream_view)
+inline void set_cuda_stream(resources& res, cuda::stream_ref stream_view)
 {
   res.add_resource_factory(std::make_shared<cuda_stream_resource_factory>(stream_view));
 };
@@ -90,7 +86,7 @@ inline void set_cuda_stream(resources& res, rmm::cuda_stream_view stream_view)
  * synchronizing on behalf of a caller, in which case forward the caller's location.
  */
 inline void sync_stream(const resources& res,
-                        rmm::cuda_stream_view stream,
+                        cuda::stream_ref stream,
                         std::source_location location = std::source_location::current())
 {
   if (raft::resource::get_dry_run_flag(res)) { return; }

--- a/cpp/include/raft/core/resource/cuda_stream_pool.hpp
+++ b/cpp/include/raft/core/resource/cuda_stream_pool.hpp
@@ -128,8 +128,9 @@ inline cuda::stream_ref get_next_usable_stream(const resources& res)
  */
 inline cuda::stream_ref get_next_usable_stream(const resources& res, std::size_t stream_idx)
 {
-  return is_stream_pool_initialized(res) ? get_stream_from_stream_pool(res, stream_idx)
-                                         : static_cast<cuda::stream_ref>(get_cuda_stream(res));
+  return is_stream_pool_initialized(res)
+           ? get_stream_from_stream_pool(res, stream_idx)
+           : static_cast<cuda::stream_ref>(get_cuda_stream(res).get());
 }
 
 /**

--- a/cpp/include/raft/core/resource/cuda_stream_pool.hpp
+++ b/cpp/include/raft/core/resource/cuda_stream_pool.hpp
@@ -117,7 +117,7 @@ inline cuda::stream_ref get_stream_from_stream_pool(const resources& res, std::s
 inline cuda::stream_ref get_next_usable_stream(const resources& res)
 {
   return is_stream_pool_initialized(res) ? get_stream_from_stream_pool(res)
-                                         : static_cast<cuda::stream_ref>(get_cuda_stream(res));
+                                         : get_cuda_stream(res);
 }
 
 /**
@@ -130,7 +130,7 @@ inline cuda::stream_ref get_next_usable_stream(const resources& res, std::size_t
 {
   return is_stream_pool_initialized(res)
            ? get_stream_from_stream_pool(res, stream_idx)
-           : static_cast<cuda::stream_ref>(get_cuda_stream(res).get());
+           : get_cuda_stream(res);
 }
 
 /**

--- a/cpp/include/raft/core/resource/cuda_stream_pool.hpp
+++ b/cpp/include/raft/core/resource/cuda_stream_pool.hpp
@@ -13,6 +13,7 @@
 
 #include <rmm/cuda_stream_pool.hpp>
 
+#include <cuda/stream>
 #include <cuda_runtime.h>
 
 namespace RAFT_EXPORT raft {
@@ -95,7 +96,7 @@ inline std::size_t get_stream_pool_size(const resources& res)
 /**
  * @brief return stream from pool
  */
-inline rmm::cuda_stream_view get_stream_from_stream_pool(const resources& res)
+inline cuda::stream_ref get_stream_from_stream_pool(const resources& res)
 {
   RAFT_EXPECTS(is_stream_pool_initialized(res), "ERROR: rmm::cuda_stream_pool was not initialized");
   return get_cuda_stream_pool(res).get_stream();
@@ -104,8 +105,7 @@ inline rmm::cuda_stream_view get_stream_from_stream_pool(const resources& res)
 /**
  * @brief return stream from pool at index
  */
-inline rmm::cuda_stream_view get_stream_from_stream_pool(const resources& res,
-                                                         std::size_t stream_idx)
+inline cuda::stream_ref get_stream_from_stream_pool(const resources& res, std::size_t stream_idx)
 {
   RAFT_EXPECTS(is_stream_pool_initialized(res), "ERROR: rmm::cuda_stream_pool was not initialized");
   return get_cuda_stream_pool(res).get_stream(stream_idx);
@@ -114,9 +114,10 @@ inline rmm::cuda_stream_view get_stream_from_stream_pool(const resources& res,
 /**
  * @brief return stream from pool if size > 0, else main stream on res
  */
-inline rmm::cuda_stream_view get_next_usable_stream(const resources& res)
+inline cuda::stream_ref get_next_usable_stream(const resources& res)
 {
-  return is_stream_pool_initialized(res) ? get_stream_from_stream_pool(res) : get_cuda_stream(res);
+  return is_stream_pool_initialized(res) ? get_stream_from_stream_pool(res)
+                                         : static_cast<cuda::stream_ref>(get_cuda_stream(res));
 }
 
 /**
@@ -125,10 +126,10 @@ inline rmm::cuda_stream_view get_next_usable_stream(const resources& res)
  * @param[in] res the raft resources object
  * @param[in] stream_idx the required index of the stream in the stream pool if available
  */
-inline rmm::cuda_stream_view get_next_usable_stream(const resources& res, std::size_t stream_idx)
+inline cuda::stream_ref get_next_usable_stream(const resources& res, std::size_t stream_idx)
 {
   return is_stream_pool_initialized(res) ? get_stream_from_stream_pool(res, stream_idx)
-                                         : get_cuda_stream(res);
+                                         : static_cast<cuda::stream_ref>(get_cuda_stream(res));
 }
 
 /**

--- a/cpp/include/raft/core/resource/cuda_stream_pool.hpp
+++ b/cpp/include/raft/core/resource/cuda_stream_pool.hpp
@@ -116,8 +116,7 @@ inline cuda::stream_ref get_stream_from_stream_pool(const resources& res, std::s
  */
 inline cuda::stream_ref get_next_usable_stream(const resources& res)
 {
-  return is_stream_pool_initialized(res) ? get_stream_from_stream_pool(res)
-                                         : get_cuda_stream(res);
+  return is_stream_pool_initialized(res) ? get_stream_from_stream_pool(res) : get_cuda_stream(res);
 }
 
 /**
@@ -128,9 +127,8 @@ inline cuda::stream_ref get_next_usable_stream(const resources& res)
  */
 inline cuda::stream_ref get_next_usable_stream(const resources& res, std::size_t stream_idx)
 {
-  return is_stream_pool_initialized(res)
-           ? get_stream_from_stream_pool(res, stream_idx)
-           : get_cuda_stream(res);
+  return is_stream_pool_initialized(res) ? get_stream_from_stream_pool(res, stream_idx)
+                                         : get_cuda_stream(res);
 }
 
 /**

--- a/cpp/include/raft/core/resource/cusolver_dn_handle.hpp
+++ b/cpp/include/raft/core/resource/cusolver_dn_handle.hpp
@@ -11,7 +11,7 @@
 #include <raft/core/resource/resource_types.hpp>
 #include <raft/core/resources.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
+#include <cuda/stream>
 
 #include <cusolverDn.h>
 
@@ -23,7 +23,7 @@ namespace resource {
  */
 class cusolver_dn_resource : public resource {
  public:
-  cusolver_dn_resource(rmm::cuda_stream_view stream)
+  cusolver_dn_resource(cuda::stream_ref stream)
   {
     RAFT_CUSOLVER_TRY_NO_THROW(cusolverDnCreate(&cusolver_res));
     RAFT_CUSOLVER_TRY_NO_THROW(cusolverDnSetStream(cusolver_res, stream.get()));
@@ -49,12 +49,12 @@ class cusolver_dn_resource : public resource {
  */
 class cusolver_dn_resource_factory : public resource_factory {
  public:
-  cusolver_dn_resource_factory(rmm::cuda_stream_view stream) : stream_(stream) {}
+  cusolver_dn_resource_factory(cuda::stream_ref stream) : stream_(stream) {}
   resource_type get_resource_type() override { return resource_type::CUSOLVER_DN_HANDLE; }
   resource* make_resource() override { return new cusolver_dn_resource(stream_); }
 
  private:
-  rmm::cuda_stream_view stream_;
+  cuda::stream_ref stream_;
 };
 
 /**

--- a/cpp/include/raft/core/resource/cusolver_sp_handle.hpp
+++ b/cpp/include/raft/core/resource/cusolver_sp_handle.hpp
@@ -10,6 +10,8 @@
 #include <raft/core/resource/resource_types.hpp>
 #include <raft/core/resources.hpp>
 
+#include <cuda/stream>
+
 #include <cusolverSp.h>
 
 namespace RAFT_EXPORT raft {
@@ -20,7 +22,7 @@ namespace resource {
  */
 class cusolver_sp_resource : public resource {
  public:
-  cusolver_sp_resource(rmm::cuda_stream_view stream)
+  cusolver_sp_resource(cuda::stream_ref stream)
   {
     RAFT_CUSOLVER_TRY_NO_THROW(cusolverSpCreate(&cusolver_res));
     RAFT_CUSOLVER_TRY_NO_THROW(cusolverSpSetStream(cusolver_res, stream.get()));
@@ -41,12 +43,12 @@ class cusolver_sp_resource : public resource {
  */
 class cusolver_sp_resource_factory : public resource_factory {
  public:
-  cusolver_sp_resource_factory(rmm::cuda_stream_view stream) : stream_(stream) {}
+  cusolver_sp_resource_factory(cuda::stream_ref stream) : stream_(stream) {}
   resource_type get_resource_type() override { return resource_type::CUSOLVER_SP_HANDLE; }
   resource* make_resource() override { return new cusolver_sp_resource(stream_); }
 
  private:
-  rmm::cuda_stream_view stream_;
+  cuda::stream_ref stream_;
 };
 
 /**

--- a/cpp/include/raft/core/resource/cusparse_handle.hpp
+++ b/cpp/include/raft/core/resource/cusparse_handle.hpp
@@ -10,13 +10,15 @@
 #include <raft/core/resource/resource_types.hpp>
 #include <raft/core/resources.hpp>
 
+#include <cuda/stream>
+
 #include <cusparse_v2.h>
 
 namespace RAFT_EXPORT raft {
 namespace resource {
 class cusparse_resource : public resource {
  public:
-  cusparse_resource(rmm::cuda_stream_view stream)
+  cusparse_resource(cuda::stream_ref stream)
   {
     RAFT_CUSPARSE_TRY_NO_THROW(cusparseCreate(&cusparse_res));
     RAFT_CUSPARSE_TRY_NO_THROW(cusparseSetStream(cusparse_res, stream.get()));
@@ -36,12 +38,12 @@ class cusparse_resource : public resource {
  */
 class cusparse_resource_factory : public resource_factory {
  public:
-  cusparse_resource_factory(rmm::cuda_stream_view stream) : stream_(stream) {}
+  cusparse_resource_factory(cuda::stream_ref stream) : stream_(stream) {}
   resource_type get_resource_type() override { return resource_type::CUSPARSE_HANDLE; }
   resource* make_resource() override { return new cusparse_resource(stream_); }
 
  private:
-  rmm::cuda_stream_view stream_;
+  cuda::stream_ref stream_;
 };
 
 /**

--- a/cpp/include/raft/core/resource/device_memory_resource.hpp
+++ b/cpp/include/raft/core/resource/device_memory_resource.hpp
@@ -11,7 +11,6 @@
 #include <raft/mr/host_device_resource.hpp>
 #include <raft/util/cudart_utils.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
 #include <rmm/mr/limiting_resource_adaptor.hpp>
 #include <rmm/mr/per_device_resource.hpp>
 #include <rmm/mr/pool_memory_resource.hpp>

--- a/cpp/include/raft/core/resource/thrust_policy.hpp
+++ b/cpp/include/raft/core/resource/thrust_policy.hpp
@@ -10,11 +10,13 @@
 #include <raft/core/resources.hpp>
 
 #include <rmm/exec_policy.hpp>
+
+#include <cuda/stream>
 namespace RAFT_EXPORT raft {
 namespace resource {
 class thrust_policy_resource : public resource {
  public:
-  thrust_policy_resource(rmm::cuda_stream_view stream_view)
+  thrust_policy_resource(cuda::stream_ref stream_view)
     : thrust_policy_(std::make_unique<rmm::exec_policy_nosync>(stream_view))
   {
   }
@@ -33,12 +35,12 @@ class thrust_policy_resource : public resource {
  */
 class thrust_policy_resource_factory : public resource_factory {
  public:
-  thrust_policy_resource_factory(rmm::cuda_stream_view stream_view) : stream_view_(stream_view) {}
+  thrust_policy_resource_factory(cuda::stream_ref stream_view) : stream_view_(stream_view) {}
   resource_type get_resource_type() override { return resource_type::THRUST_POLICY; }
   resource* make_resource() override { return new thrust_policy_resource(stream_view_); }
 
  private:
-  rmm::cuda_stream_view stream_view_;
+  cuda::stream_ref stream_view_;
 };
 
 /**

--- a/cpp/include/raft/core/stream_view.hpp
+++ b/cpp/include/raft/core/stream_view.hpp
@@ -10,7 +10,7 @@
 #ifndef RAFT_DISABLE_CUDA
 #include <raft/core/interruptible.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
+#include <cuda/stream>
 #endif
 
 #include <cuda/stream>
@@ -48,18 +48,18 @@ struct fail_stream_view {
 }  // namespace raft
 
 namespace RAFT_EXPORT raft {
-/** A lightweight wrapper around rmm::cuda_stream_view that can be used in
+/** A lightweight wrapper around cuda::stream_ref that can be used in
  * CUDA-free builds
  *
  * While CUDA-free builds should never actually make use of a CUDA stream at
  * runtime, it is sometimes useful to have a symbol that can stand in place of
  * a CUDA stream to avoid excessive ifdef directives interspersed with other
- * logic. This struct's methods invoke the underlying rmm::cuda_stream_view in
+ * logic. This struct's methods invoke the underlying cuda::stream_ref in
  * CUDA-enabled builds but throw runtime exceptions if any non-trivial method
  * is called from a CUDA-free build */
 struct stream_view {
 #ifndef RAFT_DISABLE_CUDA
-  using underlying_view_type = rmm::cuda_stream_view;
+  using underlying_view_type = cuda::stream_ref;
 #else
   using underlying_view_type = detail::fail_stream_view;
 #endif
@@ -73,12 +73,55 @@ struct stream_view {
   constexpr stream_view(stream_view&&)               = default;
   auto operator=(stream_view const&) -> stream_view& = default;
   auto operator=(stream_view&&) -> stream_view&      = default;
-  auto value() const { return base_view_.value(); }
+  auto value() const
+  {
+#ifndef RAFT_DISABLE_CUDA
+    return base_view_.get();
+#else
+    return base_view_.value();
+#endif
+  }
   operator underlying_view_type() const noexcept { return base_view_; }
-  [[nodiscard]] auto is_per_thread_default() const { return base_view_.is_per_thread_default(); }
-  [[nodiscard]] auto is_default() const { return base_view_.is_default(); }
-  void synchronize() const { base_view_.synchronize(); }
-  void synchronize_no_throw() const { base_view_.synchronize_no_throw(); }
+  [[nodiscard]] auto is_per_thread_default() const
+  {
+#ifndef RAFT_DISABLE_CUDA
+#ifdef CUDA_API_PER_THREAD_DEFAULT_STREAM
+    return value() == cudaStreamPerThread || value() == nullptr;
+#else
+    return value() == cudaStreamPerThread;
+#endif
+#else
+    return base_view_.is_per_thread_default();
+#endif
+  }
+  [[nodiscard]] auto is_default() const
+  {
+#ifndef RAFT_DISABLE_CUDA
+#ifdef CUDA_API_PER_THREAD_DEFAULT_STREAM
+    return value() == cudaStreamLegacy;
+#else
+    return value() == cudaStreamLegacy || value() == nullptr;
+#endif
+#else
+    return base_view_.is_default();
+#endif
+  }
+  void synchronize() const
+  {
+#ifndef RAFT_DISABLE_CUDA
+    base_view_.sync();
+#else
+    base_view_.synchronize();
+#endif
+  }
+  void synchronize_no_throw() const
+  {
+#ifndef RAFT_DISABLE_CUDA
+    RAFT_CUDA_TRY_NO_THROW(cudaStreamSynchronize(base_view_.get()));
+#else
+    base_view_.synchronize_no_throw();
+#endif
+  }
   /**
    * @param[in] location the call site to blame for the errors; leave at its default unless
    * synchronizing on behalf of a caller, in which case forward the caller's location.
@@ -96,7 +139,9 @@ struct stream_view {
   auto underlying() { return base_view_; }
   void synchronize_if_cuda_enabled()
   {
-    if constexpr (raft::CUDA_ENABLED) { base_view_.synchronize(); }
+#ifndef RAFT_DISABLE_CUDA
+    base_view_.sync();
+#endif
   }
 
  private:

--- a/cpp/include/raft/core/stream_view.hpp
+++ b/cpp/include/raft/core/stream_view.hpp
@@ -9,8 +9,6 @@
 #include <raft/core/logger.hpp>
 #ifndef RAFT_DISABLE_CUDA
 #include <raft/core/interruptible.hpp>
-
-#include <cuda/stream>
 #endif
 
 #include <cuda/stream>

--- a/cpp/include/raft/core/temporary_device_buffer.hpp
+++ b/cpp/include/raft/core/temporary_device_buffer.hpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2023-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2023-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/cpp/include/raft/core/temporary_device_buffer.hpp
+++ b/cpp/include/raft/core/temporary_device_buffer.hpp
@@ -12,6 +12,8 @@
 #include <raft/core/resource/cuda_stream.hpp>
 #include <raft/util/cudart_utils.hpp>
 
+#include <cuda/stream>
+
 #include <variant>
 
 namespace RAFT_EXPORT raft {
@@ -118,7 +120,7 @@ class temporary_device_buffer {
   }
 
  private:
-  rmm::cuda_stream_view stream_;
+  cuda::stream_ref stream_;
   ElementType* original_data_;
   data_store data_;
   Extents extents_;

--- a/cpp/include/raft/linalg/detail/cublaslt_wrappers.hpp
+++ b/cpp/include/raft/linalg/detail/cublaslt_wrappers.hpp
@@ -340,7 +340,7 @@ struct coef_wrapper<false, S> {
   S beta_default  = 0;
   const S* alpha;
   const S* beta;
-  coef_wrapper(const S* alpha_in, const S* beta_in, rmm::cuda_stream_view)
+  coef_wrapper(const S* alpha_in, const S* beta_in, cuda::stream_ref)
     : alpha(alpha_in == nullptr ? &alpha_default : alpha_in),
       beta(beta_in == nullptr ? &beta_default : beta_in)
   {
@@ -350,10 +350,10 @@ struct coef_wrapper<false, S> {
 template <typename S>
 struct coef_wrapper<true, S> {
   S* store = nullptr;
-  rmm::cuda_stream_view stream;
+  cuda::stream_ref stream;
   const S* alpha;
   const S* beta;
-  coef_wrapper(const S* alpha_in, const S* beta_in, rmm::cuda_stream_view stream)
+  coef_wrapper(const S* alpha_in, const S* beta_in, cuda::stream_ref stream)
     : stream(stream), alpha(alpha_in), beta(beta_in)
   {
     if (alpha != nullptr && beta != nullptr) { return; }

--- a/cpp/include/raft/linalg/detail/lstsq.cuh
+++ b/cpp/include/raft/linalg/detail/lstsq.cuh
@@ -71,7 +71,7 @@ struct DeviceEvent {
  *   if the two views point to the same stream
  *   or sometimes when one of them is the legacy default stream.
  */
-bool are_implicitly_synchronized(rmm::cuda_stream_view a, rmm::cuda_stream_view b)
+bool are_implicitly_synchronized(cuda::stream_ref a, cuda::stream_ref b)
 {
   // any stream is "synchronized" with itself
   if (a.get() == b.get()) return true;
@@ -265,8 +265,8 @@ void lstsqEig(raft::resources const& handle,
               math_t* w,
               cudaStream_t stream)
 {
-  rmm::cuda_stream_view mainStream   = rmm::cuda_stream_view(stream);
-  rmm::cuda_stream_view multAbStream = resource::get_next_usable_stream(handle);
+  cuda::stream_ref mainStream   = cuda::stream_ref(stream);
+  cuda::stream_ref multAbStream = resource::get_next_usable_stream(handle);
   bool dry_run                       = resource::get_dry_run_flag(handle);
   bool concurrent;
   if (dry_run) {

--- a/cpp/include/raft/linalg/detail/lstsq.cuh
+++ b/cpp/include/raft/linalg/detail/lstsq.cuh
@@ -267,7 +267,7 @@ void lstsqEig(raft::resources const& handle,
 {
   cuda::stream_ref mainStream   = cuda::stream_ref(stream);
   cuda::stream_ref multAbStream = resource::get_next_usable_stream(handle);
-  bool dry_run                       = resource::get_dry_run_flag(handle);
+  bool dry_run                  = resource::get_dry_run_flag(handle);
   bool concurrent;
   if (dry_run) {
     concurrent = false;

--- a/cpp/include/raft/linalg/detail/lstsq.cuh
+++ b/cpp/include/raft/linalg/detail/lstsq.cuh
@@ -77,11 +77,19 @@ bool are_implicitly_synchronized(rmm::cuda_stream_view a, rmm::cuda_stream_view 
   if (a.get() == b.get()) return true;
   // legacy + blocking streams
   unsigned int flags = 0;
-  if (a.is_default()) {
+#ifdef CUDA_API_PER_THREAD_DEFAULT_STREAM
+  if (a.get() == cudaStreamLegacy) {
+#else
+  if (a.get() == cudaStreamLegacy || a.get() == nullptr) {
+#endif
     RAFT_CUDA_TRY(cudaStreamGetFlags(b.get(), &flags));
     if ((flags & cudaStreamNonBlocking) == 0) return true;
   }
-  if (b.is_default()) {
+#ifdef CUDA_API_PER_THREAD_DEFAULT_STREAM
+  if (b.get() == cudaStreamLegacy) {
+#else
+  if (b.get() == cudaStreamLegacy || b.get() == nullptr) {
+#endif
     RAFT_CUDA_TRY(cudaStreamGetFlags(a.get(), &flags));
     if ((flags & cudaStreamNonBlocking) == 0) return true;
   }

--- a/cpp/include/raft/linalg/detail/map.cuh
+++ b/cpp/include/raft/linalg/detail/map.cuh
@@ -18,9 +18,8 @@
 #include <raft/util/vectorized.cuh>
 #include <raft/util/vectorized_kvp.cuh>
 
-#include <rmm/cuda_stream_view.hpp>
-
 #include <cuda/std/tuple>
+#include <cuda/stream>
 
 namespace raft {
 namespace linalg::detail {
@@ -93,7 +92,7 @@ RAFT_KERNEL map_kernel(OutT* out_ptr, IdxT len, Func f, const InTs*... in_ptrs)
 }
 
 template <int R, bool PassOffset, typename OutT, typename IdxT, typename Func, typename... InTs>
-void map_call(rmm::cuda_stream_view stream, OutT* out_ptr, IdxT len, Func f, const InTs*... in_ptrs)
+void map_call(cuda::stream_ref stream, OutT* out_ptr, IdxT len, Func f, const InTs*... in_ptrs)
 {
   const IdxT len_vectorized = raft::div_rounding_up_safe<IdxT>(len, R);
   const int threads =
@@ -151,7 +150,7 @@ constexpr inline auto operator*(const ratio_selector& a, const ratio_selector& b
 
 template <int R, bool PassOffset, typename OutT, typename IdxT, typename Func, typename... InTs>
 void map_call_rt(
-  int r, rmm::cuda_stream_view stream, OutT* out_ptr, IdxT len, Func f, const InTs*... in_ptrs)
+  int r, cuda::stream_ref stream, OutT* out_ptr, IdxT len, Func f, const InTs*... in_ptrs)
 {
   if (r >= R) { return map_call<R, PassOffset>(stream, out_ptr, len, f, in_ptrs...); }
   if constexpr (R > 1) {
@@ -160,7 +159,7 @@ void map_call_rt(
 }
 
 template <bool PassOffset, typename OutT, typename IdxT, typename Func, typename... InTs>
-void map(rmm::cuda_stream_view stream, OutT* out_ptr, IdxT len, Func f, const InTs*... in_ptrs)
+void map(cuda::stream_ref stream, OutT* out_ptr, IdxT len, Func f, const InTs*... in_ptrs)
 {
   // don't vectorize on small inputs
   if (len <= kSmallInputThreshold) {

--- a/cpp/include/raft/matrix/detail/select_radix.cuh
+++ b/cpp/include/raft/matrix/detail/select_radix.cuh
@@ -892,7 +892,7 @@ void radix_topk(bool dry_run,
                 const IdxT* len_i,
                 unsigned grid_dim,
                 int sm_cnt,
-                rmm::cuda_stream_view stream,
+                cuda::stream_ref stream,
                 rmm::device_async_resource_ref mr)
 {
   // TODO: is it possible to relax this restriction?
@@ -1174,7 +1174,7 @@ void radix_topk_one_block(bool dry_run,
                           bool select_min,
                           const IdxT* len_i,
                           int sm_cnt,
-                          rmm::cuda_stream_view stream,
+                          cuda::stream_ref stream,
                           rmm::device_async_resource_ref mr)
 {
   static_assert(calc_num_passes<T, BitsPerPass>() > 1);

--- a/cpp/include/raft/matrix/detail/select_warpsort.cuh
+++ b/cpp/include/raft/matrix/detail/select_warpsort.cuh
@@ -19,11 +19,11 @@
 #include <raft/util/kernel_launch.hpp>
 #include <raft/util/pow2_utils.cuh>
 
-#include <rmm/cuda_stream_view.hpp>
 #include <rmm/device_uvector.hpp>
 #include <rmm/resource_ref.hpp>
 
 #include <cub/util_type.cuh>  // cub::Traits
+#include <cuda/stream>
 
 #include <algorithm>
 #include <functional>
@@ -865,7 +865,7 @@ struct launch_setup {
                      const IdxT* in_indptr,
                      T* out_key,
                      IdxT* out_idx,
-                     rmm::cuda_stream_view stream)
+                     cuda::stream_ref stream)
   {
     const int capacity = bound_by_power_of_two(k);
     if constexpr (Capacity > 1) {
@@ -1075,7 +1075,7 @@ void select_k_(bool dry_run,
                T* out,
                IdxT* out_idx,
                bool select_min,
-               rmm::cuda_stream_view stream,
+               cuda::stream_ref stream,
                rmm::device_async_resource_ref mr)
 {
   rmm::device_uvector<T> tmp_val(num_of_block * k * batch_size, stream, mr);

--- a/cpp/include/raft/sparse/linalg/detail/masked_matmul.cuh
+++ b/cpp/include/raft/sparse/linalg/detail/masked_matmul.cuh
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2024-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2024-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 #pragma once
@@ -48,8 +48,6 @@ void masked_matmul(raft::resources const& handle,
                "Number of rows in C must match the number of rows in A.");
   RAFT_EXPECTS(B.extent(0) == compressed_C_view.get_n_cols(),
                "Number of columns in C must match the number of columns in B.");
-
-  auto stream = raft::resource::get_cuda_stream(handle);
 
   auto C_matrix = raft::make_device_csr_matrix<output_t, index_t>(handle, compressed_C_view);
 
@@ -111,8 +109,6 @@ void masked_matmul(raft::resources const& handle,
                "Number of rows in C must match the number of rows in A.");
   RAFT_EXPECTS(B.extent(0) == compressed_C_view.get_n_cols(),
                "Number of columns in C must match the number of columns in B.");
-
-  auto stream = raft::resource::get_cuda_stream(handle);
 
   auto C_matrix = raft::make_device_csr_matrix<output_t, index_t>(handle, compressed_C_view);
 

--- a/cpp/include/raft/sparse/solver/detail/lanczos_svds.cuh
+++ b/cpp/include/raft/sparse/solver/detail/lanczos_svds.cuh
@@ -186,7 +186,6 @@ ValueTypeT normalize_or_randomize(raft::resources const& handle,
                                   bool* used_random_vector)
 {
   common::nvtx::range<common::nvtx::domain::raft> scope("lanczos_svds::normalize_or_randomize");
-  auto stream         = resource::get_cuda_stream(handle);
   auto nrm            = vector_norm(handle, target, n_rows);
   *used_random_vector = false;
 

--- a/cpp/include/raft/util/cudart_utils.hpp
+++ b/cpp/include/raft/util/cudart_utils.hpp
@@ -9,8 +9,7 @@
 #include <raft/core/error.hpp>
 #include <raft/util/cuda_rt_essentials.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
-
+#include <cuda/stream>
 #include <cuda_bf16.h>
 #include <cuda_fp16.h>
 #include <cuda_runtime_api.h>
@@ -134,7 +133,7 @@ class grid_1d_block_t {
  * @param stream cuda stream
  */
 template <typename Type>
-void copy(Type* dst, const Type* src, size_t len, rmm::cuda_stream_view stream)
+void copy(Type* dst, const Type* src, size_t len, cuda::stream_ref stream)
 {
   RAFT_CUDA_TRY(cudaMemcpyAsync(dst, src, len * sizeof(Type), cudaMemcpyDefault, stream.get()));
 }
@@ -162,7 +161,7 @@ void copy_matrix(Type* dst,
                  size_t src_pitch,
                  size_t width,
                  size_t height,
-                 rmm::cuda_stream_view stream)
+                 cuda::stream_ref stream)
 {
   constexpr size_t elem_size = sizeof(Type);
   RAFT_CUDA_TRY(cudaMemcpy2DAsync(dst,
@@ -183,20 +182,20 @@ void copy_matrix(Type* dst,
  */
 /** performs a host to device copy */
 template <typename Type>
-void update_device(Type* d_ptr, const Type* h_ptr, size_t len, rmm::cuda_stream_view stream)
+void update_device(Type* d_ptr, const Type* h_ptr, size_t len, cuda::stream_ref stream)
 {
   copy(d_ptr, h_ptr, len, stream);
 }
 
 /** performs a device to host copy */
 template <typename Type>
-void update_host(Type* h_ptr, const Type* d_ptr, size_t len, rmm::cuda_stream_view stream)
+void update_host(Type* h_ptr, const Type* d_ptr, size_t len, cuda::stream_ref stream)
 {
   copy(h_ptr, d_ptr, len, stream);
 }
 
 template <typename Type>
-void copy_async(Type* d_ptr1, const Type* d_ptr2, size_t len, rmm::cuda_stream_view stream)
+void copy_async(Type* d_ptr1, const Type* d_ptr2, size_t len, cuda::stream_ref stream)
 {
   RAFT_CUDA_TRY(
     cudaMemcpyAsync(d_ptr1, d_ptr2, len * sizeof(Type), cudaMemcpyDeviceToDevice, stream.get()));

--- a/cpp/include/raft/util/kernel_launch.hpp
+++ b/cpp/include/raft/util/kernel_launch.hpp
@@ -162,7 +162,7 @@ struct launch_on {
    * @param[in] loc call site to blame for launch errors; leave at its default
    */
   launch_on(  // NOLINT(google-explicit-constructor)
-    rmm::cuda_stream_view stream,
+    cuda::stream_ref stream,
     std::size_t smem                                 = 0,
     bool kSkipExecution                              = false,
     std::initializer_list<cudaLaunchAttribute> attrs = {},

--- a/cpp/tests/core/handle.cpp
+++ b/cpp/tests/core/handle.cpp
@@ -205,7 +205,7 @@ TEST(Raft, Handle)
   // test non default stream handle
   cudaStream_t stream;
   RAFT_CUDA_TRY(cudaStreamCreate(&stream));
-  rmm::cuda_stream_view stream_view(stream);
+  cuda::stream_ref stream_view(stream);
   raft::handle_t handle(stream_view);
   ASSERT_EQ(stream_view, resource::get_cuda_stream(handle));
   resource::sync_stream(handle, stream);
@@ -385,7 +385,7 @@ TEST(Raft, ExplicitSetDoesNotPropagate)
   // Explicit set on a -- creates a new cell
   cudaStream_t raw_stream;
   RAFT_CUDA_TRY(cudaStreamCreate(&raw_stream));
-  rmm::cuda_stream_view new_stream(raw_stream);
+  cuda::stream_ref new_stream(raw_stream);
   resource::set_cuda_stream(a, new_stream);
 
   // a sees the new stream

--- a/cpp/tests/core/handle.cpp
+++ b/cpp/tests/core/handle.cpp
@@ -187,7 +187,7 @@ TEST(Raft, HandleDefault)
 {
   raft::handle_t h;
   ASSERT_EQ(0, h.get_device());
-  ASSERT_EQ(rmm::cuda_stream_per_thread, resource::get_cuda_stream(h));
+  ASSERT_EQ(cuda::stream_ref{cudaStreamPerThread}, resource::get_cuda_stream(h));
   ASSERT_NE(nullptr, h.get_cublas_handle());
   ASSERT_NE(nullptr, h.get_cusolver_dn_handle());
   ASSERT_NE(nullptr, h.get_cusolver_sp_handle());

--- a/cpp/tests/core/interruptible.cu
+++ b/cpp/tests/core/interruptible.cu
@@ -11,7 +11,8 @@
 #include <raft/util/kernel_launch.hpp>
 
 #include <rmm/cuda_stream.hpp>
-#include <rmm/cuda_stream_view.hpp>
+
+#include <cuda/stream>
 
 #include <gtest/gtest.h>
 #include <omp.h>
@@ -119,7 +120,7 @@ class capturing_stream {
   auto operator=(capturing_stream const&) -> capturing_stream& = delete;
   auto operator=(capturing_stream&&) -> capturing_stream&      = delete;
 
-  [[nodiscard]] auto view() const -> rmm::cuda_stream_view { return stream_.view(); }
+  [[nodiscard]] auto view() const -> cuda::stream_ref { return stream_.view(); }
 
  private:
   rmm::cuda_stream stream_{};

--- a/cpp/tests/core/mdarray.cu
+++ b/cpp/tests/core/mdarray.cu
@@ -44,7 +44,7 @@
 #include <memory_resource>
 
 namespace {
-void check_status(int32_t* d_status, rmm::cuda_stream_view stream)
+void check_status(int32_t* d_status, cuda::stream_ref stream)
 {
   stream.sync();
   int32_t h_status{1};

--- a/cpp/tests/core/stream_view.cpp
+++ b/cpp/tests/core/stream_view.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2023-2024, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2023-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/cpp/tests/core/stream_view.cpp
+++ b/cpp/tests/core/stream_view.cpp
@@ -8,7 +8,7 @@
 
 #include <gtest/gtest.h>
 #ifndef RAFT_DISABLE_CUDA
-#include <rmm/cuda_stream_view.hpp>
+#include <cuda/stream>
 #endif
 namespace raft {
 TEST(StreamView, Default)
@@ -26,8 +26,8 @@ TEST(StreamView, Default)
   EXPECT_NO_THROW(stream.synchronize_no_throw());
   EXPECT_NO_THROW(stream.synchronize_if_cuda_enabled());
 #ifndef RAFT_DISABLE_CUDA
-  static_assert(std::is_same_v<decltype(stream.underlying()), rmm::cuda_stream_view>,
-                "underlying should return rmm::cuda_stream_view");
+  static_assert(std::is_same_v<decltype(stream.underlying()), cuda::stream_ref>,
+                "underlying should return cuda::stream_ref");
 #endif
 }
 }  // namespace raft

--- a/cpp/tests/linalg/gemm_layout.cu
+++ b/cpp/tests/linalg/gemm_layout.cu
@@ -57,7 +57,6 @@ class GemmLayoutTest : public ::testing::TestWithParam<GemmLayoutInputs<T>> {
     params = ::testing::TestWithParam<GemmLayoutInputs<T>>::GetParam();
 
     raft::resources handle;
-    cudaStream_t stream = resource::get_cuda_stream(handle).get();
 
     raft::random::RngState r(params.seed);
 

--- a/cpp/tests/matrix/linewise_op.cu
+++ b/cpp/tests/matrix/linewise_op.cu
@@ -41,7 +41,7 @@ template <typename T, typename I, typename ParamsReader>
 struct LinewiseTest : public ::testing::TestWithParam<typename ParamsReader::Params> {
   const raft::resources handle;
   const LinewiseTestParams params;
-  rmm::cuda_stream_view stream;
+  cuda::stream_ref stream;
 
   LinewiseTest()
     : testing::TestWithParam<typename ParamsReader::Params>(),

--- a/cpp/tests/random/make_regression.cu
+++ b/cpp/tests/random/make_regression.cu
@@ -115,7 +115,7 @@ class MakeRegressionTest : public ::testing::TestWithParam<MakeRegressionInputs<
  protected:
   MakeRegressionInputs<T> params{::testing::TestWithParam<MakeRegressionInputs<T>>::GetParam()};
   raft::resources handle;
-  rmm::cuda_stream_view stream{resource::get_cuda_stream(handle)};
+  cuda::stream_ref stream{resource::get_cuda_stream(handle)};
   rmm::device_uvector<T> values_ret{size_t(params.n_samples) * size_t(params.n_targets), stream};
   rmm::device_uvector<T> values_prod{size_t(params.n_samples) * size_t(params.n_targets), stream};
 
@@ -257,7 +257,7 @@ class MakeRegressionMdspanTest : public ::testing::TestWithParam<MakeRegressionI
  private:
   MakeRegressionInputs<T> params{::testing::TestWithParam<MakeRegressionInputs<T>>::GetParam()};
   raft::resources handle;
-  rmm::cuda_stream_view stream{resource::get_cuda_stream(handle)};
+  cuda::stream_ref stream{resource::get_cuda_stream(handle)};
   rmm::device_uvector<T> values_ret{size_t(params.n_samples) * size_t(params.n_targets), stream};
   rmm::device_uvector<T> values_prod{size_t(params.n_samples) * size_t(params.n_targets), stream};
 

--- a/cpp/tests/sparse/spectral_matrix.cu
+++ b/cpp/tests/sparse/spectral_matrix.cu
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2020-2024, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -51,8 +51,6 @@ TEST(Raft, SpectralMatrices)
   sparse_matrix_t<index_type, value_type, nnz_type> sm2{h, csr_v};
   ASSERT_EQ(nullptr, sm1.row_offsets_);
   ASSERT_EQ(nullptr, sm2.row_offsets_);
-
-  auto stream = resource::get_cuda_stream(h);
 
   auto cnstr_lm1 = [&h, ro, ci, vs, nrows, nnz](void) {
     laplacian_matrix_t<index_type, value_type, nnz_type> lm1{h, ro, ci, vs, nrows, nnz};

--- a/cpp/tests/sparse/spmm.cu
+++ b/cpp/tests/sparse/spmm.cu
@@ -88,8 +88,6 @@ class SpmmTest : public ::testing::TestWithParam<SpmmInputs<T>> {
   {
     params = ::testing::TestWithParam<SpmmInputs<T>>::GetParam();
 
-    cudaStream_t stream = resource::get_cuda_stream(handle).get();
-
     // We compute Z = X * Y and compare against reference result
     // Dimensions of X : M x K
     // Dimensions of Y : K x N

--- a/cpp/tests/stats/weighted_mean.cu
+++ b/cpp/tests/stats/weighted_mean.cu
@@ -66,7 +66,6 @@ class RowWeightedMeanTest : public ::testing::TestWithParam<WeightedMeanInputs<T
     params = ::testing::TestWithParam<WeightedMeanInputs<T>>::GetParam();
     raft::random::RngState r(params.seed);
     int rows = params.M, cols = params.N, len = rows * cols;
-    auto stream = resource::get_cuda_stream(handle);
     // device-side data
     din.resize(len);
     dweights.resize(cols);
@@ -144,7 +143,6 @@ class ColWeightedMeanTest : public ::testing::TestWithParam<WeightedMeanInputs<T
     raft::random::RngState r(params.seed);
     int rows = params.M, cols = params.N, len = rows * cols;
 
-    auto stream = resource::get_cuda_stream(handle);
     // device-side data
     din.resize(len);
     dweights.resize(rows);
@@ -199,7 +197,6 @@ class WeightedMeanTest : public ::testing::TestWithParam<WeightedMeanInputs<T>> 
   {
     params = ::testing::TestWithParam<WeightedMeanInputs<T>>::GetParam();
     raft::random::RngState r(params.seed);
-    auto stream = resource::get_cuda_stream(handle);
     int rows = params.M, cols = params.N, len = rows * cols;
     auto weight_size = params.along_rows ? cols : rows;
     auto mean_size   = params.along_rows ? rows : cols;

--- a/cpp/tests/util/bitonic_sort.cu
+++ b/cpp/tests/util/bitonic_sort.cu
@@ -10,6 +10,8 @@
 #include <raft/util/cudart_utils.hpp>
 #include <raft/util/kernel_launch.hpp>
 
+#include <cuda/stream>
+
 #include <gtest/gtest.h>
 
 #include <algorithm>
@@ -68,7 +70,7 @@ RAFT_KERNEL bitonic_kernel(T* arr, bool ascending, int warp_width, int n_inputs)
 template <int Capacity>
 struct bitonic_launch {
   template <typename T>
-  static void run(const test_spec& spec, T* arr, rmm::cuda_stream_view stream)
+  static void run(const test_spec& spec, T* arr, cuda::stream_ref stream)
   {
     ASSERT(spec.capacity <= Capacity, "Invalid input: the requested capacity is too high.");
     ASSERT(spec.warp_width <= WarpSize,

--- a/cpp/tests/util/dry_run_guards.cu
+++ b/cpp/tests/util/dry_run_guards.cu
@@ -42,7 +42,6 @@ namespace raft::util {
 TEST(DryRunGuard, AddDoesNotExecute)
 {
   raft::resources res;
-  auto stream     = resource::get_cuda_stream(res);
   constexpr int n = 256;
 
   auto a   = raft::make_device_vector<float>(res, n);
@@ -75,7 +74,6 @@ TEST(DryRunGuard, AddDoesNotExecute)
 TEST(DryRunGuard, RngDoesNotExecute)
 {
   raft::resources res;
-  auto stream     = resource::get_cuda_stream(res);
   constexpr int n = 1024;
 
   auto out = raft::make_device_vector<float>(res, n);
@@ -180,7 +178,6 @@ TEST(DryRunAllocTracking, DeallocReducesCurrent)
 TEST(DryRunE2E, StatsComposite)
 {
   raft::resources res;
-  auto stream        = resource::get_cuda_stream(res);
   constexpr int rows = 256;
   constexpr int cols = 64;
 

--- a/cpp/tests/util/kernel_launch.cu
+++ b/cpp/tests/util/kernel_launch.cu
@@ -166,7 +166,7 @@ TEST(KernelLaunch, ConvertedRestrictedPointerArgument)
 TEST(KernelLaunch, StreamOverload)
 {
   raft::resources res;
-  cuda::stream_ref stream = resource::get_cuda_stream(res).get();
+  cuda::stream_ref stream = resource::get_cuda_stream(res);
   EXPECT_NO_THROW(raft::launch_kernel(stream, 1, 1, noop_kernel));
   resource::sync_stream(res);
 }

--- a/cpp/tests/util/kernel_launch.cu
+++ b/cpp/tests/util/kernel_launch.cu
@@ -14,6 +14,8 @@
 
 #include <rmm/device_uvector.hpp>
 
+#include <cuda/stream>
+
 #include <gtest/gtest.h>
 
 #include <cstdint>
@@ -89,7 +91,7 @@ concept launchable_when_moved = requires(W w)
 // is always the one of the launch. Everything else must fail to compile.
 static_assert(launchable_as_named<raft::resources&>,
               "resources must convert to a launch_on prvalue");
-static_assert(launchable_as_named<rmm::cuda_stream_view>,
+static_assert(launchable_as_named<cuda::stream_ref>,
               "a stream view must convert to a launch_on prvalue");
 static_assert(launchable_as_named<cudaStream_t>,
               "a raw stream handle must convert to a launch_on prvalue");
@@ -164,7 +166,7 @@ TEST(KernelLaunch, ConvertedRestrictedPointerArgument)
 TEST(KernelLaunch, StreamOverload)
 {
   raft::resources res;
-  auto stream = resource::get_cuda_stream(res);
+  cuda::stream_ref stream = resource::get_cuda_stream(res).get();
   EXPECT_NO_THROW(raft::launch_kernel(stream, 1, 1, noop_kernel));
   resource::sync_stream(res);
 }
@@ -180,7 +182,7 @@ TEST(KernelLaunch, RawStreamHandleOverload)
 TEST(KernelLaunch, SharedMemory)
 {
   raft::resources res;
-  auto stream = resource::get_cuda_stream(res);
+  cuda::stream_ref stream = resource::get_cuda_stream(res);
   rmm::device_uvector<int> out(1, stream);
   RAFT_CUDA_TRY(cudaMemsetAsync(out.data(), 0, sizeof(int), stream.get()));
 
@@ -252,7 +254,7 @@ TEST(KernelLaunch, DryRunIgnoresBadConfig)
 TEST(KernelLaunch, SkipExecutionOnStream)
 {
   raft::resources res;
-  auto stream = resource::get_cuda_stream(res);
+  cuda::stream_ref stream = resource::get_cuda_stream(res);
   rmm::device_uvector<int> out(1, stream);
   RAFT_CUDA_TRY(cudaMemsetAsync(out.data(), 0, sizeof(int), stream.get()));
 

--- a/cpp/tests/util/reduction.cu
+++ b/cpp/tests/util/reduction.cu
@@ -77,7 +77,7 @@ struct reduction_launch {
   static void run(const rmm::device_uvector<int>& arr_d,
                   int ref_val,
                   ReduceLambda reduce_op,
-                  rmm::cuda_stream_view stream)
+                  cuda::stream_ref stream)
   {
     rmm::device_scalar<int> ref_d(stream);
     const int block_dim = 64;
@@ -94,7 +94,7 @@ struct reduction_launch {
                          int ref_val,
                          int rank_ref_val,
                          ReduceLambda reduce_op,
-                         rmm::cuda_stream_view stream)
+                         cuda::stream_ref stream)
   {
     rmm::device_scalar<int> ref_d(stream);
     rmm::device_scalar<int> rank_d(stream);
@@ -116,7 +116,7 @@ struct reduction_launch {
 
   static void run_random_sample(const rmm::device_uvector<int>& arr_d,
                                 int ref_val,
-                                rmm::cuda_stream_view stream)
+                                cuda::stream_ref stream)
   {
     rmm::device_scalar<int> ref_d(stream);
     const int block_dim = 64;
@@ -130,7 +130,7 @@ struct reduction_launch {
 
   static void run_binary(const rmm::device_uvector<int>& arr_d,
                          int ref_val,
-                         rmm::cuda_stream_view stream)
+                         cuda::stream_ref stream)
   {
     rmm::device_scalar<int> ref_d(stream);
     constexpr int block_dim = 64;
@@ -151,7 +151,7 @@ template <typename T>
 class ReductionTest : public testing::TestWithParam<std::vector<int>> {  // NOLINT
  protected:
   const std::vector<int> input;    // NOLINT
-  rmm::cuda_stream_view stream;    // NOLINT
+  cuda::stream_ref stream;         // NOLINT
   rmm::device_uvector<int> arr_d;  // NOLINT
 
  public:

--- a/docs/source/developer_guide.md
+++ b/docs/source/developer_guide.md
@@ -48,7 +48,7 @@ int n_streams = get_stream_pool_size(res);
 #pragma omp parallel for num_threads(n_streams)
 for(int i = 0; i < n; i++) {
     int thread_num    = omp_get_thread_num() % n_streams;
-    auto s            = get_stream_from_stream_pool(res, thread_num);  // rmm::cuda_stream_view
+    auto s            = get_stream_from_stream_pool(res, thread_num);  // cuda::stream_ref
     ... possible light cpu pre-processing ...
     my_kernel1<<<b, tpb, 0, s>>>(...);
     ...
@@ -448,7 +448,7 @@ All RAFT algorithms should be as asynchronous as possible avoiding the use of th
 
 void foo(const raft::resources& res, ...)
 {
-    auto stream = get_cuda_stream(res);  // rmm::cuda_stream_view
+    auto stream = get_cuda_stream(res);  // cuda::stream_ref
 }
 ```
 When multiple streams are needed, e.g. to manage a pipeline, use the internal streams available in `raft::resources` (see [Resource Management](#resource-management)). If multiple streams are used all operations still must be ordered according to `raft::resource::get_cuda_stream()` (from `raft/core/resource/cuda_stream.hpp`). Before any operation in any of the internal CUDA streams is started, all previous work in `raft::resource::get_cuda_stream()` must have completed. Any work enqueued in `raft::resource::get_cuda_stream()` after a RAFT function returns should not start before all work enqueued in the internal streams has completed. E.g. if a RAFT algorithm is called like this:
@@ -520,7 +520,7 @@ void foo(const raft::resources& res, ...)
     cublasHandle_t cublasHandle = get_cublas_handle(res);
     const int num_streams       = get_stream_pool_size(res);
     const int stream_idx        = ...
-    auto stream                 = get_stream_from_stream_pool(res, stream_idx);  // rmm::cuda_stream_view
+    auto stream                 = get_stream_from_stream_pool(res, stream_idx);  // cuda::stream_ref
     ...
 }
 ```

--- a/python/pylibraft/pylibraft/common/handle.pxd
+++ b/python/pylibraft/pylibraft/common/handle.pxd
@@ -12,9 +12,8 @@
 from libcpp.memory cimport shared_ptr, unique_ptr
 from libcpp.vector cimport vector
 
-from cuda.bindings.cyruntime cimport cudaStream_t
-
 from rmm.librmm.cuda_stream_pool cimport cuda_stream_pool
+from rmm.librmm.cuda_stream_ref cimport stream_ref
 
 
 # Keeping `handle_t` around for backwards compatibility at the
@@ -22,20 +21,20 @@ from rmm.librmm.cuda_stream_pool cimport cuda_stream_pool
 cdef extern from "raft/core/handle.hpp" namespace "raft" nogil:
     cdef cppclass handle_t:
         handle_t() except +
-        handle_t(cudaStream_t stream_view) except +
-        handle_t(cudaStream_t stream_view,
+        handle_t(stream_ref stream_view) except +
+        handle_t(stream_ref stream_view,
                  shared_ptr[cuda_stream_pool] stream_pool) except +
-        cudaStream_t get_stream() except +
+        stream_ref get_stream() except +
         void sync_stream() except +
 
 
 cdef extern from "raft/core/device_resources.hpp" namespace "raft" nogil:
     cdef cppclass device_resources:
         device_resources() except +
-        device_resources(cudaStream_t stream_view) except +
-        device_resources(cudaStream_t stream_view,
+        device_resources(stream_ref stream_view) except +
+        device_resources(stream_ref stream_view,
                          shared_ptr[cuda_stream_pool] stream_pool) except +
-        cudaStream_t get_stream() except +
+        stream_ref get_stream() except +
         void sync_stream() except +
 
 cdef class DeviceResources:

--- a/python/pylibraft/pylibraft/common/handle.pxd
+++ b/python/pylibraft/pylibraft/common/handle.pxd
@@ -1,5 +1,5 @@
 #
-# SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 

--- a/python/pylibraft/pylibraft/common/handle.pyx
+++ b/python/pylibraft/pylibraft/common/handle.pyx
@@ -12,6 +12,7 @@ import functools
 
 from cuda.bindings.cyruntime cimport cudaStream_t
 from libc.stdint cimport uintptr_t
+from rmm.librmm.cuda_stream_ref cimport stream_ref
 
 # cudaStreamPerThread is not exported by cuda.bindings.cyruntime, declare it directly
 cdef extern from "cuda_runtime_api.h" nogil:
@@ -75,24 +76,26 @@ cdef class DeviceResources:
         if stream is None:
             # Use per-thread default stream, which is non-blocking
             if n_streams > 0:
-                self.c_obj.reset(new handle_t(cudaStreamPerThread, self.stream_pool))
+                self.c_obj.reset(
+                    new handle_t(stream_ref(cudaStreamPerThread), self.stream_pool)
+                )
             else:
-                self.c_obj.reset(new handle_t(cudaStreamPerThread))
+                self.c_obj.reset(new handle_t(stream_ref(cudaStreamPerThread)))
         elif hasattr(stream, '__cuda_stream__'):
             # __cuda_stream__ protocol: returns (version, pointer)
             proto = stream.__cuda_stream__()
             c_stream_t = <cudaStream_t><uintptr_t>proto[1]
             if n_streams > 0:
-                self.c_obj.reset(new handle_t(c_stream_t, self.stream_pool))
+                self.c_obj.reset(new handle_t(stream_ref(c_stream_t), self.stream_pool))
             else:
-                self.c_obj.reset(new handle_t(c_stream_t))
+                self.c_obj.reset(new handle_t(stream_ref(c_stream_t)))
         elif isinstance(stream, int):
             # Raw cudaStream_t pointer (e.g., from cupy)
             c_stream_t = <cudaStream_t><uintptr_t>stream
             if n_streams > 0:
-                self.c_obj.reset(new handle_t(c_stream_t, self.stream_pool))
+                self.c_obj.reset(new handle_t(stream_ref(c_stream_t), self.stream_pool))
             else:
-                self.c_obj.reset(new handle_t(c_stream_t))
+                self.c_obj.reset(new handle_t(stream_ref(c_stream_t)))
         else:
             raise TypeError("stream must be a Stream object, int cudaStream_t pointer, "
                             "or an object implementing the __cuda_stream__ protocol")
@@ -118,7 +121,7 @@ cdef class DeviceResources:
         if self.n_streams > 0:
             self.stream_pool.reset(new cuda_stream_pool(self.n_streams))
 
-        self.c_obj.reset(new device_resources(cudaStreamPerThread,
+        self.c_obj.reset(new device_resources(stream_ref(cudaStreamPerThread),
                                               self.stream_pool))
 
 
@@ -179,7 +182,7 @@ cdef class Handle(DeviceResources):
         if self.n_streams > 0:
             self.stream_pool.reset(new cuda_stream_pool(self.n_streams))
 
-        self.c_obj.reset(new handle_t(cudaStreamPerThread,
+        self.c_obj.reset(new handle_t(stream_ref(cudaStreamPerThread),
                                       self.stream_pool))
 
 

--- a/python/pylibraft/pylibraft/common/handle.pyx
+++ b/python/pylibraft/pylibraft/common/handle.pyx
@@ -1,5 +1,5 @@
 #
-# SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 


### PR DESCRIPTION
## Summary

Track the coordinated migration of stream APIs and call sites from `rmm::cuda_stream_view` to CCCL's `cuda::stream_ref`. This propagates `cuda::stream_ref` through RMM containers and memory resources, RAFT resource and handle APIs, downstream C++ interfaces, Python/Cython bindings, benchmarks, tests, and documentation.

This changes RAFT resource and handle stream accessors and affected APIs to return or accept `cuda::stream_ref`, with explicit raw-handle extraction at CUDA and library boundaries.

Depends on rapidsai/rmm#2372.

Tracked in rapidsai/build-planning#318.

## Migrations

- Pass `cuda::stream_ref` through stream pools, resource accessors, conditionals, and downstream APIs without converting to `rmm::cuda_stream_view`
- Use `cuda::stream_ref` constructions for default/legacy/per-thread streams
  - `rmm::cuda_stream_default` ➡️ `cuda::stream_ref{cudaStream_t{cudaStreamDefault}}`
  - `rmm::cuda_stream_legacy` ➡️ `cuda::stream_ref{cudaStreamLegacy}`
  - `rmm::cuda_stream_per_thread` ➡️ `cuda::stream_ref{cudaStreamPerThread}`
- Use `.get()` when calling an API that requires a raw `cudaStream_t`, including CUDA runtime, library, CUB, and legacy API boundaries (previously `rmm::cuda_stream_view` used `value()`)
- Use `.sync()` when synchronizing a `cuda::stream_ref` (previously `rmm::cuda_stream_view` used `synchronize()`)
- Update Cython declarations and call sites to pass stream references directly where supported
