### PR TITLE
Synchronize MST edge count update

### DIFF
--- a/cpp/include/raft/sparse/solver/detail/mst_solver_inl.cuh
+++ b/cpp/include/raft/sparse/solver/detail/mst_solver_inl.cuh
@@ -6,6 +6,7 @@
 #pragma once
 
 #include <raft/core/detail/macros.hpp>
+#include <raft/core/resource/cuda_stream.hpp>
 #include <raft/core/resource/device_properties.hpp>
 #include <raft/core/resource/dry_run_flag.hpp>
 #include <raft/core/resource/thrust_policy.hpp>
@@ -174,6 +175,7 @@ Graph_COO<vertex_t, edge_t, weight_t> MST_solver<vertex_t, edge_t, weight_t, alt
 
     // copy this iteration's results and store
     prev_mst_edge_count.set_value_async(curr_mst_edge_count, stream);
+    resource::sync_stream(handle, stream);
   }
 
   // result packaging


### PR DESCRIPTION
Synchronize the MST stream after asynchronously copying the current edge count from a loop-local host value into `prev_mst_edge_count`.

`rmm::device_scalar::set_value_async()` requires its host source to remain alive until the stream is synchronized. Without the synchronization, the copied edge count can be corrupted after the loop iteration ends and later used as the output offset for `thrust::copy_if`.

This addresses the illegal-address failure observed in the cuGraph MST test on GB300: https://github.com/rapidsai/cugraph/actions/runs/33161386555/job/98885855224#step:12:3056
