### PR TITLE
Backport: Enable public docs features in CI

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -112,6 +112,7 @@ html_theme = "nvidia_sphinx_theme"
 # documentation.
 #
 html_theme_options = {
+    "public_docs_features": os.environ.get("CI") == "true",
     "external_links": [],
     "icon_links": [
         {


### PR DESCRIPTION
Contributes to https://github.com/rapidsai/build-planning/issues/319

Backports https://github.com/NVIDIA/raft/pull/3131
