### PR TITLE
Fix striding in mdspan 1d copies

### DIFF
--- a/cpp/include/raft/core/detail/copy.hpp
+++ b/cpp/include/raft/core/detail/copy.hpp
@@ -303,12 +303,10 @@ __device__ auto increment_indices(IdxType* indices,
       }
     }(i);
 
-    auto cur_index = IdxType{};
-
-    while (cur_index < md.extent(real_index) - 1 && increment >= index_strides[real_index]) {
-      increment -= index_strides[real_index];
-      ++cur_index;
-    }
+    auto const max_index = md.extent(real_index) - IdxType{1};
+    auto const quotient  = increment / index_strides[real_index];
+    auto const cur_index = quotient < max_index ? quotient : max_index;
+    increment -= cur_index * index_strides[real_index];
     indices[real_index] = cur_index;
   }
 

--- a/cpp/tests/core/mdspan_copy.cu
+++ b/cpp/tests/core/mdspan_copy.cu
@@ -16,12 +16,14 @@
 #include <cstdint>
 
 namespace raft {
-TEST(MDSpanCopy, Mdspan1DDeviceDeviceCuda)
+class MDSpanCopy1DDeviceDeviceCuda : public testing::TestWithParam<std::int64_t> {};
+
+TEST_P(MDSpanCopy1DDeviceDeviceCuda, Copy)
 {
-  auto res            = device_resources{};
-  auto constexpr cols = std::int64_t{4096};
-  auto input  = make_device_vector<std::int64_t, std::int64_t, layout_c_contiguous>(res, cols);
-  auto output = make_device_vector<int, std::int64_t, layout_c_contiguous>(res, cols);
+  auto res        = device_resources{};
+  auto const cols = GetParam();
+  auto input      = make_device_vector<std::int64_t, std::int64_t, layout_c_contiguous>(res, cols);
+  auto output     = make_device_vector<int, std::int64_t, layout_c_contiguous>(res, cols);
 
   for (auto i = std::int64_t{}; i < cols; ++i) {
     input(i) = i;
@@ -40,6 +42,14 @@ TEST(MDSpanCopy, Mdspan1DDeviceDeviceCuda)
     ASSERT_EQ(output(i), static_cast<int>(i));
   }
 }
+
+INSTANTIATE_TEST_SUITE_P(MDSpanCopy,
+                         MDSpanCopy1DDeviceDeviceCuda,
+                         testing::Values(std::int64_t{1023},
+                                         std::int64_t{1024},
+                                         std::int64_t{1025},
+                                         std::int64_t{4096},
+                                         std::int64_t{4097}));
 
 TEST(MDSpanCopy, Mdspan3DDeviceDeviceCuda)
 {

--- a/cpp/tests/core/mdspan_copy.cu
+++ b/cpp/tests/core/mdspan_copy.cu
@@ -20,17 +20,20 @@ TEST(MDSpanCopy, Mdspan1DDeviceDeviceCuda)
 {
   auto res            = device_resources{};
   auto constexpr cols = std::int64_t{4096};
-  auto input = make_device_vector<std::int64_t, std::int64_t, layout_c_contiguous>(res, cols);
+  auto input  = make_device_vector<std::int64_t, std::int64_t, layout_c_contiguous>(res, cols);
   auto output = make_device_vector<int, std::int64_t, layout_c_contiguous>(res, cols);
 
   for (auto i = std::int64_t{}; i < cols; ++i) {
     input(i) = i;
   }
 
-  static_assert(detail::mdspan_copyable_with_kernel_v<decltype(output.view()), decltype(input.view())>,
-                "Current implementation should use kernel for this copy");
+  static_assert(
+    detail::mdspan_copyable_with_kernel_v<decltype(output.view()), decltype(input.view())>,
+    "Current implementation should use kernel for this copy");
   execute_with_dry_run_check(
-    res, [&](raft::resources const& r) { copy(r, output.view(), input.view()); }, alloc_behavior::NO_ALLOCATIONS);
+    res,
+    [&](raft::resources const& r) { copy(r, output.view(), input.view()); },
+    alloc_behavior::NO_ALLOCATIONS);
   res.sync_stream();
 
   for (auto i = std::int64_t{}; i < cols; ++i) {

--- a/cpp/tests/core/mdspan_copy.cu
+++ b/cpp/tests/core/mdspan_copy.cu
@@ -16,6 +16,28 @@
 #include <cstdint>
 
 namespace raft {
+TEST(MDSpanCopy, Mdspan1DDeviceDeviceCuda)
+{
+  auto res            = device_resources{};
+  auto constexpr cols = std::int64_t{4096};
+  auto input = make_device_vector<std::int64_t, std::int64_t, layout_c_contiguous>(res, cols);
+  auto output = make_device_vector<int, std::int64_t, layout_c_contiguous>(res, cols);
+
+  for (auto i = std::int64_t{}; i < cols; ++i) {
+    input(i) = i;
+  }
+
+  static_assert(detail::mdspan_copyable_with_kernel_v<decltype(output.view()), decltype(input.view())>,
+                "Current implementation should use kernel for this copy");
+  execute_with_dry_run_check(
+    res, [&](raft::resources const& r) { copy(r, output.view(), input.view()); }, alloc_behavior::NO_ALLOCATIONS);
+  res.sync_stream();
+
+  for (auto i = std::int64_t{}; i < cols; ++i) {
+    ASSERT_EQ(output(i), static_cast<int>(i));
+  }
+}
+
 TEST(MDSpanCopy, Mdspan3DDeviceDeviceCuda)
 {
   auto res                   = device_resources{};


### PR DESCRIPTION
I accidentally stumbled upon this bug, while trying to convert a 4096 1D mdspan from `int32` to `int64`. This approach leads to `0 + 1 + … + 4095 = 8,386,560` iterations on the device, leading to incredibly degenerate performance.

`raft::copy` uses a CUDA kernel for type-converting mdspan copies. That kernel converts each flat thread index into an mdspan coordinate.

For a 1-D vector of four elements, the old code finds element `3` by repeatedly subtracting the stride:

```text
increment = 3, stride = 1

3 → 2 → 1 → 0   # three loop iterations
```

Copying all four elements performs `0 + 1 + 2 + 3 = 6` iterations just to recover coordinates. For an `N`-element vector, this grows to roughly `N² / 2`.

Replace the repeated-subtraction loop with division and multiplication:

```text
index = increment / stride
increment -= index * stride
```

This makes coordinate calculation constant-time per element while preserving the existing general mdspan copy behavior. 

In general, the previous subtraction approach is leads to degenerate performance in N-D matrices when one or few dimensions are far larger than others.