### PR TITLE
Relax lanczos gtest tolerance

### DIFF
--- a/cpp/tests/sparse/solver/lanczos.cu
+++ b/cpp/tests/sparse/solver/lanczos.cu
@@ -117,7 +117,7 @@ template <typename ValueType>
 ValueType eigenvalue_tolerance(ValueType frobenius_norm)
 {
   auto eps = std::numeric_limits<ValueType>::epsilon();
-  return ValueType(500) * std::max(frobenius_norm, ValueType(1)) * eps;
+  return ValueType(10000) * std::max(frobenius_norm, ValueType(1)) * eps;
 }
 
 /**
@@ -192,12 +192,12 @@ void expect_valid_eigenpairs(
 
   // Eigenvalue-accuracy tolerance -- applied to the ascending-order check and
   // the Rayleigh-quotient check. Both carry the magnitude of A, so the noise
-  // floor is proportional to ||A||_F * eps. Measured across all fixtures on
-  // sm_75/CUDA 13 these stay within ~15 * ||A||_F * eps with no dependence on
-  // n, so n is deliberately not a factor (including it would inflate the RMAT
-  // tolerance ~40x and let a 1% eigenvalue error pass). This is held tight for
-  // every mode: Lanczos returns accurate eigenVALUES even when the
-  // eigenVECTOR is poorly conditioned.
+  // floor is proportional to ||A||_F * eps. Cross-platform SM results have
+  // varied by up to ~4300 * ||A||_F * eps, so allow enough margin for GPU and
+  // CUDA-version differences. The tolerance deliberately has no n factor,
+  // which would inflate the RMAT tolerance ~40x and let a 1% eigenvalue error
+  // pass. This remains tight enough to catch meaningful eigenvalue errors even
+  // when the eigenVECTOR is poorly conditioned.
   const ValueType eigenvalue_tol = eigenvalue_tolerance(frobenius_norm);
 
   // Eigenvector-accuracy tolerances -- applied to the residual, unit-norm and

--- a/cpp/tests/sparse/solver/lanczos.cu
+++ b/cpp/tests/sparse/solver/lanczos.cu
@@ -46,6 +46,7 @@
 #include <cmath>
 #include <cstdint>
 #include <limits>
+#include <type_traits>
 
 namespace raft::sparse::solver {
 
@@ -116,8 +117,9 @@ ValueType compute_frobenius_norm(raft::resources const& handle, ValueType const*
 template <typename ValueType>
 ValueType eigenvalue_tolerance(ValueType frobenius_norm)
 {
-  auto eps = std::numeric_limits<ValueType>::epsilon();
-  return ValueType(10000) * std::max(frobenius_norm, ValueType(1)) * eps;
+  auto eps        = std::numeric_limits<ValueType>::epsilon();
+  auto multiplier = std::is_same_v<ValueType, double> ? ValueType(10000) : ValueType(500);
+  return multiplier * std::max(frobenius_norm, ValueType(1)) * eps;
 }
 
 /**


### PR DESCRIPTION
This was too tight of a tolerance causing a flaky test.
```
[ RUN      ] LanczosTests/LanczosTestD_SM.Result/0
/tmp/conda-bld-output/bld/rattler-build_libraft-headers-only/work/cpp/tests/sparse/solver/lanczos.cu:425: Failure
The difference between host_eigenvalues[i] and expected[i] is 9.9339252102037534e-12, which exceeds tol, where
host_eigenvalues[i] evaluates to 0.013678224628902495,
expected[i] evaluates to 0.01367822461896857, and
tol evaluates to 1.1695277001426182e-12.
eigenvalue 1 (which=3) is not part of the requested selection: got=0.013678224628902495 expected (from independent dense reference spectrum)=0.01367822461896857

[  FAILED  ] LanczosTests/LanczosTestD_SM.Result/0, where GetParam() = 112-byte object <02-00 00-00 14-00 00-00 A0-86 01-00 00-00 00-00 00-00 00-00 7D-1D 90-26 03-00 00-00 00-00 00-00 2A-00 00-00 00-00 00-00 90-BB A0-E2 B7-5C 00-00 24-BD A0-E2 B7-5C 00-00 24-BD A0-E2 B7-5C 00-00 10-25 A1-E2 B7-5C 00-00 10-37 A1-E2 B7-5C 00-00 10-37 A1-E2 B7-5C 00-00 20-37 A1-E2 B7-5C 00-00 20-5B A1-E2 B7-5C 00-00 20-5B A1-E2 B7-5C 00-00> (55889 ms)
[----------] 1 test from LanczosTests/LanczosTestD_SM (55889 ms total)
```
